### PR TITLE
CredentialServiceのターゲットをGistGet専用に変更

### DIFF
--- a/src/GistGet/GistGet/Infrastructure/CredentialService.cs
+++ b/src/GistGet/GistGet/Infrastructure/CredentialService.cs
@@ -7,7 +7,7 @@ namespace GistGet.Infrastructure;
 
 public class CredentialService(string targetName) : ICredentialService
 {
-    public CredentialService() : this("git:https://github.com")
+    public CredentialService() : this("gistget:https://github.com/nuitsjp/GistGet")
     {
     }
 


### PR DESCRIPTION
## 変更内容CredentialService.csの資格情報ターゲットを変更しました。- **変更前**: \git:https://github.com\- **変更後**: \gistget:https://github.com/nuitsjp/GistGet\## 理由GistGet専用のCredential Managerターゲットを使用することで、既存のgit資格情報と競合しなくなります。## テスト全テスト（82件）が正常に通過することを確認済み。