### PR TITLE
feat: search gists by filename

### DIFF
--- a/src/GistGet.Test/GistGet/Constants.Test.cs
+++ b/src/GistGet.Test/GistGet/Constants.Test.cs
@@ -1,0 +1,28 @@
+using Shouldly;
+using Xunit;
+
+namespace GistGet;
+
+public class ConstantsTests
+{
+    public class DefaultValues
+    {
+        [Fact]
+        public void DefaultGistFileName_ShouldBeGistGetYaml()
+        {
+            // -------------------------------------------------------------------
+            // Arrange
+            // -------------------------------------------------------------------
+
+            // -------------------------------------------------------------------
+            // Act
+            // -------------------------------------------------------------------
+            var result = Constants.DefaultGistFileName;
+
+            // -------------------------------------------------------------------
+            // Assert
+            // -------------------------------------------------------------------
+            result.ShouldBe("gistget.yaml");
+        }
+    }
+}

--- a/src/GistGet/GistGet/Constants.cs
+++ b/src/GistGet/GistGet/Constants.cs
@@ -3,7 +3,7 @@ namespace GistGet;
 public static class Constants
 {
     public const string ProductHeader = "GistGet";
-    public const string DefaultGistFileName = "packages.yaml";
+    public const string DefaultGistFileName = "gistget.yaml";
     public const string DefaultGistDescription = "GistGet Packages";
     public const string ClientId = "Ov23lihQJhLB6hCnEIvS";
 }

--- a/src/GistGet/GistGet/IGitHubService.cs
+++ b/src/GistGet/GistGet/IGitHubService.cs
@@ -14,18 +14,8 @@
 ///   <item>
 ///     <term>gistUrl未指定時</term>
 ///     <description>
-///       認証ユーザーの全Gistを検索し、以下のいずれかの条件に一致するGistを特定します:
-///       <list type="number">
-///         <item>指定されたファイル名（gistFileName）を含むGist</item>
-///         <item>指定された説明（gistDescription）と一致するGist</item>
-///       </list>
-///     </description>
-///   </item>
-///   <item>
-///     <term>複数Gist一致時</term>
-///     <description>
-///       条件に一致するGistが複数存在する場合、<see cref="InvalidOperationException"/>をスローし、
-///       明示的なgistURL指定を要求します。
+///       認証ユーザーのGistをページングし、指定されたファイル名（gistFileName）を含む最初のGistを選択します。
+///       一致するGistが存在しない場合はプライベートGistを新規作成し、空のYAMLファイルを配置します。
 ///     </description>
 ///   </item>
 /// </list>
@@ -51,7 +41,7 @@ public interface IGitHubService
     /// 認証ユーザーの Gist からパッケージ一覧を取得します。
     /// </summary>
     /// <param name="token">GitHub アクセストークン</param>
-    /// <param name="gistFileName">Gist内のファイル名（通常は "packages.yaml"）</param>
+    /// <param name="gistFileName">Gist内のファイル名（通常は "gistget.yaml"）</param>
     /// <param name="gistDescription">Gistの説明（検索・作成時に使用）</param>
     /// <returns>パッケージ一覧</returns>
     Task<IReadOnlyList<GistGetPackage>> GetPackagesAsync(string token, string gistFileName, string gistDescription);
@@ -62,7 +52,7 @@ public interface IGitHubService
     /// </summary>
     /// <param name="token">GitHub アクセストークン</param>
     /// <param name="gistUrl">Gist URL（空文字列の場合は認証ユーザーのGistを検索または作成）</param>
-    /// <param name="gistFileName">Gist内のファイル名（通常は "packages.yaml"）</param>
+    /// <param name="gistFileName">Gist内のファイル名（通常は "gistget.yaml"）</param>
     /// <param name="gistDescription">Gistの説明</param>
     /// <param name="packages">保存するパッケージ一覧</param>
     Task SavePackagesAsync(string token, string gistUrl, string gistFileName, string gistDescription, IReadOnlyList<GistGetPackage> packages);


### PR DESCRIPTION
## Summary
- change the default gist file name to gistget.yaml
- search gists by filename with pagination and auto-create a private empty gist when missing
- add coverage for the new search behavior and default filename

## Testing
- dotnet test src/GistGet.Test/GistGet.Test.csproj -c Debug