### PR TITLE
feat: support sync --file option and add progress logs

### DIFF
--- a/src/GistGet/GistGet/IGistGetService.cs
+++ b/src/GistGet/GistGet/IGistGetService.cs
@@ -69,8 +69,9 @@ public interface IGistGetService
     /// 差分を検出し、インストール/アンインストール/pin設定を実行します。
     /// </summary>
     /// <param name="url">同期元の YAML URL（省略時は認証ユーザーの Gist）</param>
+    /// <param name="filePath">同期元のローカル YAML ファイルパス（指定時はこれを優先）</param>
     /// <returns>同期結果（インストール/アンインストール/失敗したパッケージ一覧）</returns>
-    Task<SyncResult> SyncAsync(string? url = null);
+    Task<SyncResult> SyncAsync(string? url = null, string? filePath = null);
 
     /// <summary>
     /// 指定されたコマンドをWinGetにそのままパススルーで実行します。
@@ -94,4 +95,3 @@ public interface IGistGetService
     /// <param name="filePath">読み込むYAMLファイルのパス</param>
     Task ImportAsync(string filePath);
 }
-

--- a/src/GistGet/GistGet/Presentation/CommandBuilder.cs
+++ b/src/GistGet/GistGet/Presentation/CommandBuilder.cs
@@ -32,11 +32,14 @@ public class CommandBuilder(IGistGetService gistGetService)
     {
         var command = new Command("sync", "Synchronize packages with Gist");
         var urlOption = new Option<string?>("--url", "Gist URL to sync from (optional)");
+        var fileOption = new Option<string?>("--file", "Local YAML file path to sync from (optional)");
+        fileOption.AddAlias("-f");
         command.Add(urlOption);
+        command.Add(fileOption);
 
-        command.SetHandler(async url =>
+        command.SetHandler(async (url, filePath) =>
         {
-            var result = await gistGetService.SyncAsync(url);
+            var result = await gistGetService.SyncAsync(url, filePath);
 
             // 結果を表示
             if (result.Installed.Count > 0)
@@ -105,7 +108,7 @@ public class CommandBuilder(IGistGetService gistGetService)
             {
                 AnsiConsole.MarkupLine("[green]Sync completed successfully.[/]");
             }
-        }, urlOption);
+        }, urlOption, fileOption);
 
         return command;
     }


### PR DESCRIPTION
## Summary
- add \\--file\\ to sync to prefer local YAML with existence check before URL/Gist fallback
- log sync progress for install/uninstall/pin operations via console output
- extend SyncAsync unit tests for file input and progress logging (TDD)
- Sample: dotnet run --project src/GistGet/GistGet.csproj -- sync --file .\\packages.yaml`n
## Testing
- dotnet test src/GistGet.Test/GistGet.Test.csproj -c Debug