### PR TITLE
chore: カバレッジ取得の改善

### DIFF
--- a/coverlet.runsettings
+++ b/coverlet.runsettings
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat code coverage">
+        <Configuration>
+          <Format>cobertura</Format>
+          <ExcludeByFile>
+            **/obj/**/*.cs;
+            **\\obj\\**\\*.cs;
+            **/UnitGenerator/**/*.g.cs;
+            **\\UnitGenerator\\**\\*.g.cs;
+            **/*.g.cs;
+            **\\*.g.cs
+          </ExcludeByFile>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/scripts/Analyze-Coverage.ps1
+++ b/scripts/Analyze-Coverage.ps1
@@ -1,0 +1,132 @@
+<#
+.SYNOPSIS
+    Analyze cobertura coverage results and enforce a minimum threshold.
+
+.PARAMETER ResultsDirectory
+    Directory that contains coverage.cobertura.xml files. Defaults to ../TestResults.
+
+.PARAMETER Threshold
+    Minimum line coverage percentage required to pass. Set to 0 to skip enforcement.
+
+.PARAMETER Top
+    Number of lowest coverage files to display.
+
+.PARAMETER ExcludePatterns
+    Regex patterns for file paths to exclude from the coverage summary.
+    Defaults exclude obj folders, generated *.g.cs files, Program.cs, and GitHubClientFactory.cs.
+#>
+
+param(
+    [string]$ResultsDirectory = "$(Split-Path -Parent $PSScriptRoot)\TestResults",
+    [double]$Threshold = 0,
+    [int]$Top = 5,
+    [string[]]$ExcludePatterns = @(
+        '[\\/]obj[\\/]',
+        '\.g\.cs$',
+        'Program\.cs$',
+        'GitHubClientFactory\.cs$'
+    )
+)
+
+$ErrorActionPreference = "Stop"
+
+function Get-LatestCoverageFile {
+    param([string]$Root)
+
+    $files = Get-ChildItem -Path $Root -Recurse -Filter "coverage.cobertura.xml" | Sort-Object LastWriteTime -Descending
+    if (-not $files) {
+        throw "coverage.cobertura.xml が見つかりませんでした。まずテストを実行してカバレージを生成してください。"
+    }
+
+    return $files[0]
+}
+
+function Get-CoverageSummary {
+    param(
+        [string]$FilePath,
+        [string[]]$ExcludePatterns
+    )
+
+    [xml]$xml = Get-Content -Path $FilePath
+    $classes = $xml.coverage.packages.package.classes.class
+
+    if ($ExcludePatterns -and $ExcludePatterns.Count -gt 0) {
+        $classes = $classes | Where-Object {
+            $file = $_.filename
+            -not ($ExcludePatterns | Where-Object { $file -match $_ })
+        }
+    }
+
+    $fileMap = @{}
+    foreach ($cls in $classes) {
+        $file = $cls.filename
+        if (-not $fileMap.ContainsKey($file)) {
+            $fileMap[$file] = [pscustomobject]@{
+                File    = $file
+                Covered = 0
+                Total   = 0
+            }
+        }
+
+        foreach ($line in $cls.lines.line) {
+            $fileMap[$file].Total++
+            if ([int]$line.hits -gt 0) {
+                $fileMap[$file].Covered++
+            }
+        }
+    }
+
+    $files = $fileMap.Values | ForEach-Object {
+        $coverage = if ($_.Total -eq 0) { 0 } else { ($_.Covered / $_.Total) * 100 }
+        [pscustomobject]@{
+            File     = $_.File
+            Covered  = $_.Covered
+            Total    = $_.Total
+            Coverage = $coverage
+        }
+    }
+
+    $coveredTotal = ($files | Measure-Object -Property Covered -Sum).Sum
+    $linesTotal = ($files | Measure-Object -Property Total -Sum).Sum
+    $lineCoverage = if ($linesTotal -eq 0) { 0 } else { ($coveredTotal / $linesTotal) * 100 }
+
+    return [pscustomobject]@{
+        FilePath      = $FilePath
+        LineCoverage  = $lineCoverage
+        BranchCoverage = [double]$xml.coverage.'branch-rate' * 100
+        Files         = $files
+        CoveredLines  = $coveredTotal
+        TotalLines    = $linesTotal
+    }
+}
+
+$coverageFile = Get-LatestCoverageFile -Root $ResultsDirectory
+$summary = Get-CoverageSummary -FilePath $coverageFile.FullName -ExcludePatterns $ExcludePatterns
+
+Write-Host "Coverage file: $($coverageFile.FullName)" -ForegroundColor Gray
+Write-Host ("Line coverage : {0:N2}% ({1}/{2} lines)" -f $summary.LineCoverage, $summary.CoveredLines, $summary.TotalLines) -ForegroundColor Cyan
+Write-Host ("Branch coverage: {0:N2}%" -f $summary.BranchCoverage) -ForegroundColor Cyan
+
+if ($ExcludePatterns -and $ExcludePatterns.Count -gt 0) {
+    Write-Host "Excluded patterns: $($ExcludePatterns -join ', ')" -ForegroundColor Gray
+}
+
+if ($Top -gt 0) {
+    Write-Host ""
+    Write-Host "Coverage (lowest $Top files):" -ForegroundColor Yellow
+    $summary.Files
+        | Sort-Object Coverage
+        | Select-Object -First $Top
+        | ForEach-Object {
+            Write-Host ("  {0,-70} {1,6:N2}% ({2}/{3})" -f $_.File, $_.Coverage, $_.Covered, $_.Total)
+        }
+}
+
+if ($Threshold -gt 0) {
+    if ($summary.LineCoverage -lt $Threshold) {
+        Write-Host ("Coverage threshold not met: {0:N2}% < {1:N2}%" -f $summary.LineCoverage, $Threshold) -ForegroundColor Red
+        exit 1
+    }
+
+    Write-Host ("Coverage threshold met: {0:N2}% >= {1:N2}%" -f $summary.LineCoverage, $Threshold) -ForegroundColor Green
+}

--- a/src/GistGet.Test/GistGet/Infrastructure/Diagnostics/ProcessRunnerTests.cs
+++ b/src/GistGet.Test/GistGet/Infrastructure/Diagnostics/ProcessRunnerTests.cs
@@ -1,0 +1,34 @@
+using System.Diagnostics;
+using GistGet.Infrastructure.Diagnostics;
+using Shouldly;
+
+namespace GistGet.Infrastructure.Diagnostics;
+
+public class ProcessRunnerTests
+{
+    [Fact]
+    public async Task RunAsync_ReturnsProcessExitCode()
+    {
+        // -------------------------------------------------------------------
+        // Arrange
+        // -------------------------------------------------------------------
+        var target = new ProcessRunner();
+        var startInfo = new ProcessStartInfo("cmd.exe", "/c exit 7")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        // -------------------------------------------------------------------
+        // Act
+        // -------------------------------------------------------------------
+        var exitCode = await target.RunAsync(startInfo);
+
+        // -------------------------------------------------------------------
+        // Assert
+        // -------------------------------------------------------------------
+        exitCode.ShouldBe(7);
+    }
+}

--- a/src/GistGet.Test/GistGet/Infrastructure/GitHubService.Test.cs
+++ b/src/GistGet.Test/GistGet/Infrastructure/GitHubService.Test.cs
@@ -1,3 +1,8 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Reflection;
+using System.Collections.Generic;
 using Octokit;
 using Shouldly;
 using Moq;
@@ -9,16 +14,17 @@ public class GitHubServiceTests
 
     protected readonly ICredentialService CredentialService = new CredentialService();
     protected readonly Mock<IConsoleService> ConsoleServiceMock = new();
+    protected readonly IGitHubClientFactory GitHubClientFactory = new GitHubClientFactory();
 
     protected GitHubService CreateTarget()
     {
-        return new GitHubService(CredentialService, ConsoleServiceMock.Object);
+        return new GitHubService(CredentialService, ConsoleServiceMock.Object, GitHubClientFactory);
     }
 
     protected sealed class TestableGitHubService : GitHubService
     {
-        public TestableGitHubService(ICredentialService credentialService, IConsoleService consoleService)
-            : base(credentialService, consoleService)
+        public TestableGitHubService(ICredentialService credentialService, IConsoleService consoleService, IGitHubClientFactory gitHubClientFactory)
+            : base(credentialService, consoleService, gitHubClientFactory)
         {
         }
 
@@ -26,6 +32,32 @@ public class GitHubServiceTests
         {
             return CreateDeviceFlowRequest();
         }
+    }
+
+    private sealed class StubHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly string _content;
+
+        public StubHttpMessageHandler(string content)
+        {
+            _content = content;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(_content)
+            };
+
+            return Task.FromResult(response);
+        }
+    }
+
+    private static void SetProperty<TTarget>(TTarget target, string propertyName, object? value)
+    {
+        var property = typeof(TTarget).GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        property!.SetValue(target, value);
     }
 
     protected async Task<(GitHubClient Client, string Token, Gist Gist)?> CreateIsolatedGistAsync(string fileName, string description, string initialContent)
@@ -253,7 +285,7 @@ public class GitHubServiceTests
             // -------------------------------------------------------------------
             // Arrange
             // -------------------------------------------------------------------
-            var target = new TestableGitHubService(CredentialService, ConsoleServiceMock.Object);
+            var target = new TestableGitHubService(CredentialService, ConsoleServiceMock.Object, GitHubClientFactory);
 
             // -------------------------------------------------------------------
             // Act
@@ -320,6 +352,642 @@ public class GitHubServiceTests
             // -------------------------------------------------------------------
             ConsoleServiceMock.Verify(x => x.ReadLine(), Times.Once);
             result.ShouldBe("");
+        }
+    }
+
+    public class LoginAsync : GitHubServiceTests
+    {
+        [Fact]
+        public async Task OpensBrowserAndReturnsCredential()
+        {
+            // -------------------------------------------------------------------
+            // Arrange
+            // -------------------------------------------------------------------
+            var credentialService = new Mock<ICredentialService>();
+            var consoleService = new Mock<IConsoleService>();
+            consoleService.Setup(x => x.ReadLine()).Returns(string.Empty);
+
+            var deviceFlowResponse = new OauthDeviceFlowResponse(
+                "device-code",
+                "USER-CODE",
+                "https://example.com/verify",
+                900,
+                5);
+
+            var token = new OauthToken();
+            SetProperty(token, "AccessToken", "token-xyz");
+
+            var user = new User();
+            SetProperty(user, "Login", "octocat");
+
+            var unauthenticatedClient = new Mock<IGitHubClientWrapper>();
+            unauthenticatedClient
+                .Setup(x => x.InitiateDeviceFlowAsync(It.IsAny<OauthDeviceFlowRequest>()))
+                .ReturnsAsync(deviceFlowResponse);
+            unauthenticatedClient
+                .Setup(x => x.CreateAccessTokenForDeviceFlowAsync(Constants.ClientId, deviceFlowResponse))
+                .ReturnsAsync(token);
+
+            var authenticatedClient = new Mock<IGitHubClientWrapper>();
+            authenticatedClient.Setup(x => x.GetCurrentUserAsync()).ReturnsAsync(user);
+
+            var factory = new Mock<IGitHubClientFactory>();
+            factory
+                .SetupSequence(x => x.Create(It.IsAny<string?>()))
+                .Returns(unauthenticatedClient.Object)
+                .Returns(authenticatedClient.Object);
+
+            var target = new TestableGitHubServiceForLogin(credentialService.Object, consoleService.Object, factory.Object);
+
+            // -------------------------------------------------------------------
+            // Act
+            // -------------------------------------------------------------------
+            var credential = await target.LoginAsync();
+
+            // -------------------------------------------------------------------
+            // Assert
+            // -------------------------------------------------------------------
+            consoleService.Verify(x => x.SetClipboard("USER-CODE"), Times.Once);
+            consoleService.Verify(x => x.WriteWarning(It.Is<string>(m => m.Contains("USER-CODE"))), Times.Once);
+            consoleService.Verify(x => x.WriteInfo(It.Is<string>(m => m.Contains("https://example.com/verify"))), Times.Once);
+            consoleService.Verify(x => x.ReadLine(), Times.Once);
+            target.OpenedUrls.ShouldContain("https://example.com/verify");
+            credential.Username.ShouldBe("octocat");
+            credential.Token.ShouldBe("token-xyz");
+        }
+
+        private sealed class TestableGitHubServiceForLogin : GitHubService
+        {
+            public List<string> OpenedUrls { get; } = new();
+
+            public TestableGitHubServiceForLogin(ICredentialService credentialService, IConsoleService consoleService, IGitHubClientFactory gitHubClientFactory)
+                : base(credentialService, consoleService, gitHubClientFactory)
+            {
+            }
+
+            protected override bool OpenBrowser(string verificationUri)
+            {
+                OpenedUrls.Add(verificationUri);
+                return true;
+            }
+        }
+    }
+
+    public class GetTokenStatusAsync : GitHubServiceTests
+    {
+        [Fact]
+        public async Task WithValidToken_ReturnsLoginAndScopes()
+        {
+            // -------------------------------------------------------------------
+            // Arrange
+            // -------------------------------------------------------------------
+            var credentialService = new Mock<ICredentialService>();
+            var consoleService = new Mock<IConsoleService>();
+
+            var usersClient = new Mock<IGitHubClientWrapper>();
+            var user = new User();
+            SetProperty(user, "Login", "octocat");
+            usersClient.Setup(x => x.GetCurrentUserAsync()).ReturnsAsync(user);
+
+            var apiInfo = new ApiInfo(
+                new Dictionary<string, Uri>(),
+                new List<string> { "gist", "repo" },
+                new List<string>(),
+                string.Empty,
+                new RateLimit(5000, 4999, DateTimeOffset.UtcNow.ToUnixTimeSeconds()),
+                TimeSpan.Zero);
+
+            usersClient.Setup(x => x.GetLastApiInfo()).Returns(apiInfo);
+
+            var factory = new Mock<IGitHubClientFactory>();
+            factory.Setup(x => x.Create("token-123")).Returns(usersClient.Object);
+
+            var target = new GitHubService(credentialService.Object, consoleService.Object, factory.Object);
+
+            // -------------------------------------------------------------------
+            // Act
+            // -------------------------------------------------------------------
+            var status = await target.GetTokenStatusAsync("token-123");
+
+            // -------------------------------------------------------------------
+            // Assert
+            // -------------------------------------------------------------------
+            status.Username.ShouldBe("octocat");
+            status.Scopes.ShouldContain("gist");
+            status.Scopes.ShouldContain("repo");
+        }
+    }
+
+    public class GetPackagesFromUrlAsyncMock : GitHubServiceTests
+    {
+        [Fact]
+        public async Task WithEmptyContent_ReturnsEmptyCollection()
+        {
+            // -------------------------------------------------------------------
+            // Arrange
+            // -------------------------------------------------------------------
+            var credentialService = new Mock<ICredentialService>();
+            var consoleService = new Mock<IConsoleService>();
+            var httpClient = new HttpClient(new StubHttpMessageHandler(string.Empty));
+            var factory = new Mock<IGitHubClientFactory>();
+            factory.Setup(x => x.Create(It.IsAny<string?>())).Returns(Mock.Of<IGitHubClientWrapper>());
+            var target = new GitHubService(credentialService.Object, consoleService.Object, factory.Object, httpClient);
+
+            // -------------------------------------------------------------------
+            // Act
+            // -------------------------------------------------------------------
+            var result = await target.GetPackagesFromUrlAsync("https://example.com/gist");
+
+            // -------------------------------------------------------------------
+            // Assert
+            // -------------------------------------------------------------------
+            result.ShouldBeEmpty();
+        }
+    }
+
+    public class GetPackagesAsyncMock : GitHubServiceTests
+    {
+        [Fact]
+        public async Task WithMatchingGist_DeserializesPackages()
+        {
+            // -------------------------------------------------------------------
+            // Arrange
+            // -------------------------------------------------------------------
+            var credentialService = new Mock<ICredentialService>();
+            var consoleService = new Mock<IConsoleService>();
+
+            var listingGist = new Gist();
+            SetProperty(listingGist, "Id", "1");
+            SetProperty(listingGist, "Files", new Dictionary<string, GistFile>
+            {
+                { "packages.yaml", new GistFile(0, "packages.yaml", string.Empty, string.Empty, string.Empty, string.Empty) }
+            });
+
+            var detailGist = new Gist();
+            SetProperty(detailGist, "Id", "1");
+            SetProperty(detailGist, "Files", new Dictionary<string, GistFile>
+            {
+                { "packages.yaml", new GistFile(0, "packages.yaml", string.Empty, string.Empty, "Foo.Bar: {}\n", string.Empty) }
+            });
+
+            var clientWrapper = new Mock<IGitHubClientWrapper>();
+            clientWrapper.Setup(x => x.GetAllGistsAsync()).ReturnsAsync(new List<Gist> { listingGist });
+            clientWrapper.Setup(x => x.GetGistAsync("1")).ReturnsAsync(detailGist);
+
+            var factory = new Mock<IGitHubClientFactory>();
+            factory.Setup(x => x.Create("token")).Returns(clientWrapper.Object);
+
+            var target = new GitHubService(credentialService.Object, consoleService.Object, factory.Object);
+
+            // -------------------------------------------------------------------
+            // Act
+            // -------------------------------------------------------------------
+            var result = await target.GetPackagesAsync("token", "packages.yaml", "description");
+
+            // -------------------------------------------------------------------
+            // Assert
+            // -------------------------------------------------------------------
+            result.ShouldHaveSingleItem().Id.ShouldBe("Foo.Bar");
+        }
+
+        [Fact]
+        public async Task WithStoredCredentialToken_UsesFallbackToken()
+        {
+            // -------------------------------------------------------------------
+            // Arrange
+            // -------------------------------------------------------------------
+            var stored = new Credential("stored-user", "stored-token");
+            var credentialService = new Mock<ICredentialService>();
+            credentialService.Setup(x => x.TryGetCredential(out stored)).Returns(true);
+            var consoleService = new Mock<IConsoleService>();
+
+            var listingGist = new Gist();
+            SetProperty(listingGist, "Id", "1");
+            SetProperty(listingGist, "Files", new Dictionary<string, GistFile>
+            {
+                { "packages.yaml", new GistFile(0, "packages.yaml", string.Empty, string.Empty, string.Empty, string.Empty) }
+            });
+
+            var detailGist = new Gist();
+            SetProperty(detailGist, "Id", "1");
+            SetProperty(detailGist, "Files", new Dictionary<string, GistFile>
+            {
+                { "packages.yaml", new GistFile(0, "packages.yaml", string.Empty, string.Empty, "Foo.Bar: {}\n", string.Empty) }
+            });
+
+            var clientWrapper = new Mock<IGitHubClientWrapper>();
+            clientWrapper.Setup(x => x.GetAllGistsAsync()).ReturnsAsync(new List<Gist> { listingGist });
+            clientWrapper.Setup(x => x.GetGistAsync("1")).ReturnsAsync(detailGist);
+
+            var factory = new Mock<IGitHubClientFactory>();
+            factory.Setup(x => x.Create("stored-token")).Returns(clientWrapper.Object);
+
+            var target = new GitHubService(credentialService.Object, consoleService.Object, factory.Object);
+
+            // -------------------------------------------------------------------
+            // Act
+            // -------------------------------------------------------------------
+            var result = await target.GetPackagesAsync(string.Empty, "packages.yaml", "description");
+
+            // -------------------------------------------------------------------
+            // Assert
+            // -------------------------------------------------------------------
+            factory.Verify(x => x.Create("stored-token"), Times.Once);
+            result.ShouldHaveSingleItem().Id.ShouldBe("Foo.Bar");
+        }
+
+        [Fact]
+        public async Task WithoutAnyToken_ThrowsInvalidOperation()
+        {
+            // -------------------------------------------------------------------
+            // Arrange
+            // -------------------------------------------------------------------
+            var credentialService = new Mock<ICredentialService>();
+            Credential? missing = null;
+            credentialService.Setup(x => x.TryGetCredential(out missing!)).Returns(false);
+            var consoleService = new Mock<IConsoleService>();
+            var factory = new Mock<IGitHubClientFactory>();
+
+            var target = new GitHubService(credentialService.Object, consoleService.Object, factory.Object);
+
+            // -------------------------------------------------------------------
+            // Act & Assert
+            // -------------------------------------------------------------------
+            await Should.ThrowAsync<InvalidOperationException>(() =>
+                target.GetPackagesAsync(string.Empty, "packages.yaml", "description"));
+            factory.Verify(x => x.Create(It.IsAny<string?>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task WhenNoMatchingGist_ReturnsEmpty()
+        {
+            // -------------------------------------------------------------------
+            // Arrange
+            // -------------------------------------------------------------------
+            var credentialService = new Mock<ICredentialService>();
+            var consoleService = new Mock<IConsoleService>();
+
+            var clientWrapper = new Mock<IGitHubClientWrapper>();
+            clientWrapper.Setup(x => x.GetAllGistsAsync()).ReturnsAsync(new List<Gist>());
+
+            var factory = new Mock<IGitHubClientFactory>();
+            factory.Setup(x => x.Create("token")).Returns(clientWrapper.Object);
+
+            var target = new GitHubService(credentialService.Object, consoleService.Object, factory.Object);
+
+            // -------------------------------------------------------------------
+            // Act
+            // -------------------------------------------------------------------
+            var result = await target.GetPackagesAsync("token", "packages.yaml", "description");
+
+            // -------------------------------------------------------------------
+            // Assert
+            // -------------------------------------------------------------------
+            result.ShouldBeEmpty();
+            clientWrapper.Verify(x => x.GetGistAsync(It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task WithEmptyContent_ReturnsEmpty()
+        {
+            // -------------------------------------------------------------------
+            // Arrange
+            // -------------------------------------------------------------------
+            var credentialService = new Mock<ICredentialService>();
+            var consoleService = new Mock<IConsoleService>();
+
+            var listingGist = new Gist();
+            SetProperty(listingGist, "Id", "1");
+            SetProperty(listingGist, "Files", new Dictionary<string, GistFile>
+            {
+                { "packages.yaml", new GistFile(0, "packages.yaml", string.Empty, string.Empty, string.Empty, string.Empty) }
+            });
+
+            var detailGist = new Gist();
+            SetProperty(detailGist, "Id", "1");
+            SetProperty(detailGist, "Files", new Dictionary<string, GistFile>
+            {
+                { "packages.yaml", new GistFile(0, "packages.yaml", string.Empty, string.Empty, string.Empty, string.Empty) }
+            });
+
+            var clientWrapper = new Mock<IGitHubClientWrapper>();
+            clientWrapper.Setup(x => x.GetAllGistsAsync()).ReturnsAsync(new List<Gist> { listingGist });
+            clientWrapper.Setup(x => x.GetGistAsync("1")).ReturnsAsync(detailGist);
+
+            var factory = new Mock<IGitHubClientFactory>();
+            factory.Setup(x => x.Create("token")).Returns(clientWrapper.Object);
+
+            var target = new GitHubService(credentialService.Object, consoleService.Object, factory.Object);
+
+            // -------------------------------------------------------------------
+            // Act
+            // -------------------------------------------------------------------
+            var result = await target.GetPackagesAsync("token", "packages.yaml", "description");
+
+            // -------------------------------------------------------------------
+            // Assert
+            // -------------------------------------------------------------------
+            result.ShouldBeEmpty();
+        }
+
+        [Fact]
+        public async Task WithMissingTargetFile_UsesFirstYamlFile()
+        {
+            // -------------------------------------------------------------------
+            // Arrange
+            // -------------------------------------------------------------------
+            var credentialService = new Mock<ICredentialService>();
+            var consoleService = new Mock<IConsoleService>();
+
+            var listingGist = new Gist();
+            SetProperty(listingGist, "Id", "1");
+            SetProperty(listingGist, "Description", "description");
+            SetProperty(listingGist, "Files", new Dictionary<string, GistFile>
+            {
+                { "other.yml", new GistFile(0, "other.yml", string.Empty, string.Empty, string.Empty, string.Empty) }
+            });
+
+            var detailGist = new Gist();
+            SetProperty(detailGist, "Id", "1");
+            SetProperty(detailGist, "Files", new Dictionary<string, GistFile>
+            {
+                { "other.yml", new GistFile(0, "other.yml", string.Empty, string.Empty, "Other.Package: {}\n", string.Empty) }
+            });
+
+            var clientWrapper = new Mock<IGitHubClientWrapper>();
+            clientWrapper.Setup(x => x.GetAllGistsAsync()).ReturnsAsync(new List<Gist> { listingGist });
+            clientWrapper.Setup(x => x.GetGistAsync("1")).ReturnsAsync(detailGist);
+
+            var factory = new Mock<IGitHubClientFactory>();
+            factory.Setup(x => x.Create("token")).Returns(clientWrapper.Object);
+
+            var target = new GitHubService(credentialService.Object, consoleService.Object, factory.Object);
+
+            // -------------------------------------------------------------------
+            // Act
+            // -------------------------------------------------------------------
+            var result = await target.GetPackagesAsync("token", "packages.yaml", "description");
+
+            // -------------------------------------------------------------------
+            // Assert
+            // -------------------------------------------------------------------
+            result.ShouldHaveSingleItem().Id.ShouldBe("Other.Package");
+        }
+
+        [Fact]
+        public async Task WithMultipleMatches_ThrowsInvalidOperation()
+        {
+            // -------------------------------------------------------------------
+            // Arrange
+            // -------------------------------------------------------------------
+            var credentialService = new Mock<ICredentialService>();
+            var consoleService = new Mock<IConsoleService>();
+
+            var gistByFile = new Gist();
+            SetProperty(gistByFile, "Id", "1");
+            SetProperty(gistByFile, "Files", new Dictionary<string, GistFile>
+            {
+                { "packages.yaml", new GistFile(0, "packages.yaml", string.Empty, string.Empty, string.Empty, string.Empty) }
+            });
+
+            var gistByDescription = new Gist();
+            SetProperty(gistByDescription, "Id", "2");
+            SetProperty(gistByDescription, "Description", "description");
+            SetProperty(gistByDescription, "Files", new Dictionary<string, GistFile>());
+
+            var clientWrapper = new Mock<IGitHubClientWrapper>();
+            clientWrapper.Setup(x => x.GetAllGistsAsync()).ReturnsAsync(new List<Gist> { gistByFile, gistByDescription });
+
+            var factory = new Mock<IGitHubClientFactory>();
+            factory.Setup(x => x.Create("token")).Returns(clientWrapper.Object);
+
+            var target = new GitHubService(credentialService.Object, consoleService.Object, factory.Object);
+
+            // -------------------------------------------------------------------
+            // Act & Assert
+            // -------------------------------------------------------------------
+            await Should.ThrowAsync<InvalidOperationException>(() =>
+                target.GetPackagesAsync("token", "packages.yaml", "description"));
+        }
+    }
+
+    public class SavePackagesAsyncMock : GitHubServiceTests
+    {
+        [Fact]
+        public async Task WhenGistExists_EditsFileWithSerializedContent()
+        {
+            // -------------------------------------------------------------------
+            // Arrange
+            // -------------------------------------------------------------------
+            var credentialService = new Mock<ICredentialService>();
+            var consoleService = new Mock<IConsoleService>();
+            var packages = new List<GistGetPackage>
+            {
+                new() { Id = "Foo.Bar", Version = "1.0.0" }
+            };
+
+            var existingGist = new Gist();
+            SetProperty(existingGist, "Id", "gist-1");
+            SetProperty(existingGist, "Files", new Dictionary<string, GistFile>
+            {
+                { "packages.yaml", new GistFile(0, "packages.yaml", string.Empty, string.Empty, string.Empty, string.Empty) }
+            });
+
+            var clientWrapper = new Mock<IGitHubClientWrapper>();
+            clientWrapper.Setup(x => x.GetAllGistsAsync()).ReturnsAsync(new List<Gist> { existingGist });
+
+            GistUpdate? captured = null;
+            clientWrapper
+                .Setup(x => x.EditGistAsync("gist-1", It.IsAny<GistUpdate>()))
+                .Callback<string, GistUpdate>((_, update) => captured = update)
+                .ReturnsAsync(new Gist());
+
+            var factory = new Mock<IGitHubClientFactory>();
+            factory.Setup(x => x.Create("token")).Returns(clientWrapper.Object);
+
+            var target = new GitHubService(credentialService.Object, consoleService.Object, factory.Object);
+
+            // -------------------------------------------------------------------
+            // Act
+            // -------------------------------------------------------------------
+            await target.SavePackagesAsync("token", "https://gist.github.com/gist-1", "packages.yaml", "description", packages);
+
+            // -------------------------------------------------------------------
+            // Assert
+            // -------------------------------------------------------------------
+            captured.ShouldNotBeNull();
+            captured!.Files.ShouldContainKey("packages.yaml");
+            captured.Files["packages.yaml"].Content.ShouldContain("Foo.Bar");
+        }
+
+        [Fact]
+        public async Task WhenNoMatchingGist_CreatesNewPrivateGist()
+        {
+            // -------------------------------------------------------------------
+            // Arrange
+            // -------------------------------------------------------------------
+            var credentialService = new Mock<ICredentialService>();
+            var consoleService = new Mock<IConsoleService>();
+            var packages = new List<GistGetPackage> { new() { Id = "New.Package" } };
+
+            var clientWrapper = new Mock<IGitHubClientWrapper>();
+            clientWrapper.Setup(x => x.GetAllGistsAsync()).ReturnsAsync(new List<Gist>());
+
+            NewGist? created = null;
+            clientWrapper
+                .Setup(x => x.CreateGistAsync(It.IsAny<NewGist>()))
+                .Callback<NewGist>(gist => created = gist)
+                .ReturnsAsync(new Gist());
+
+            var factory = new Mock<IGitHubClientFactory>();
+            factory.Setup(x => x.Create("token")).Returns(clientWrapper.Object);
+
+            var target = new GitHubService(credentialService.Object, consoleService.Object, factory.Object);
+
+            // -------------------------------------------------------------------
+            // Act
+            // -------------------------------------------------------------------
+            await target.SavePackagesAsync("token", string.Empty, "packages.yaml", "GistGet Packages", packages);
+
+            // -------------------------------------------------------------------
+            // Assert
+            // -------------------------------------------------------------------
+            created.ShouldNotBeNull();
+            created!.Public.ShouldBeFalse();
+            created.Description.ShouldBe("GistGet Packages");
+            created.Files.ShouldContainKey("packages.yaml");
+            created.Files["packages.yaml"].ShouldContain("New.Package");
+        }
+
+        [Fact]
+        public async Task WhenMatchingGistExistsWithoutUrl_EditsExistingGist()
+        {
+            // -------------------------------------------------------------------
+            // Arrange
+            // -------------------------------------------------------------------
+            var credentialService = new Mock<ICredentialService>();
+            var consoleService = new Mock<IConsoleService>();
+            var packages = new List<GistGetPackage> { new() { Id = "Package.A" } };
+
+            var existingGist = new Gist();
+            SetProperty(existingGist, "Id", "gist-123");
+            SetProperty(existingGist, "Files", new Dictionary<string, GistFile>
+            {
+                { "packages.yaml", new GistFile(0, "packages.yaml", string.Empty, string.Empty, string.Empty, string.Empty) }
+            });
+
+            var clientWrapper = new Mock<IGitHubClientWrapper>();
+            clientWrapper.Setup(x => x.GetAllGistsAsync()).ReturnsAsync(new List<Gist> { existingGist });
+            clientWrapper.Setup(x => x.EditGistAsync("gist-123", It.IsAny<GistUpdate>())).ReturnsAsync(new Gist());
+
+            var factory = new Mock<IGitHubClientFactory>();
+            factory.Setup(x => x.Create("token")).Returns(clientWrapper.Object);
+
+            var target = new GitHubService(credentialService.Object, consoleService.Object, factory.Object);
+
+            // -------------------------------------------------------------------
+            // Act
+            // -------------------------------------------------------------------
+            await target.SavePackagesAsync("token", string.Empty, "packages.yaml", "description", packages);
+
+            // -------------------------------------------------------------------
+            // Assert
+            // -------------------------------------------------------------------
+            clientWrapper.Verify(x => x.EditGistAsync("gist-123", It.IsAny<GistUpdate>()), Times.Once);
+            clientWrapper.Verify(x => x.CreateGistAsync(It.IsAny<NewGist>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task WithRawGistId_UsesProvidedId()
+        {
+            // -------------------------------------------------------------------
+            // Arrange
+            // -------------------------------------------------------------------
+            var credentialService = new Mock<ICredentialService>();
+            var consoleService = new Mock<IConsoleService>();
+            var packages = new List<GistGetPackage> { new() { Id = "Package.A" } };
+
+            var clientWrapper = new Mock<IGitHubClientWrapper>();
+            GistUpdate? captured = null;
+            clientWrapper
+                .Setup(x => x.EditGistAsync("raw-id", It.IsAny<GistUpdate>()))
+                .Callback<string, GistUpdate>((_, update) => captured = update)
+                .ReturnsAsync(new Gist());
+
+            var factory = new Mock<IGitHubClientFactory>();
+            factory.Setup(x => x.Create("token")).Returns(clientWrapper.Object);
+
+            var target = new GitHubService(credentialService.Object, consoleService.Object, factory.Object);
+
+            // -------------------------------------------------------------------
+            // Act
+            // -------------------------------------------------------------------
+            await target.SavePackagesAsync("token", "raw-id", "packages.yaml", "description", packages);
+
+            // -------------------------------------------------------------------
+            // Assert
+            // -------------------------------------------------------------------
+            captured.ShouldNotBeNull();
+            clientWrapper.Verify(x => x.EditGistAsync("raw-id", It.IsAny<GistUpdate>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task WithMultipleMatches_ThrowsInvalidOperation()
+        {
+            // -------------------------------------------------------------------
+            // Arrange
+            // -------------------------------------------------------------------
+            var credentialService = new Mock<ICredentialService>();
+            var consoleService = new Mock<IConsoleService>();
+
+            var gistByFile = new Gist();
+            SetProperty(gistByFile, "Id", "1");
+            SetProperty(gistByFile, "Files", new Dictionary<string, GistFile>
+            {
+                { "packages.yaml", new GistFile(0, "packages.yaml", string.Empty, string.Empty, string.Empty, string.Empty) }
+            });
+
+            var gistByDescription = new Gist();
+            SetProperty(gistByDescription, "Id", "2");
+            SetProperty(gistByDescription, "Description", "description");
+            SetProperty(gistByDescription, "Files", new Dictionary<string, GistFile>());
+
+            var clientWrapper = new Mock<IGitHubClientWrapper>();
+            clientWrapper.Setup(x => x.GetAllGistsAsync()).ReturnsAsync(new List<Gist> { gistByFile, gistByDescription });
+
+            var factory = new Mock<IGitHubClientFactory>();
+            factory.Setup(x => x.Create("token")).Returns(clientWrapper.Object);
+
+            var target = new GitHubService(credentialService.Object, consoleService.Object, factory.Object);
+
+            // -------------------------------------------------------------------
+            // Act & Assert
+            // -------------------------------------------------------------------
+            await Should.ThrowAsync<InvalidOperationException>(() =>
+                target.SavePackagesAsync("token", string.Empty, "packages.yaml", "description", Array.Empty<GistGetPackage>()));
+        }
+
+        [Fact]
+        public async Task WithoutAnyToken_ThrowsInvalidOperation()
+        {
+            // -------------------------------------------------------------------
+            // Arrange
+            // -------------------------------------------------------------------
+            var credentialService = new Mock<ICredentialService>();
+            Credential? missing = null;
+            credentialService.Setup(x => x.TryGetCredential(out missing!)).Returns(false);
+
+            var consoleService = new Mock<IConsoleService>();
+            var factory = new Mock<IGitHubClientFactory>();
+
+            var target = new GitHubService(credentialService.Object, consoleService.Object, factory.Object);
+
+            // -------------------------------------------------------------------
+            // Act & Assert
+            // -------------------------------------------------------------------
+            await Should.ThrowAsync<InvalidOperationException>(() =>
+                target.SavePackagesAsync(string.Empty, string.Empty, "packages.yaml", "description", Array.Empty<GistGetPackage>()));
+            factory.Verify(x => x.Create(It.IsAny<string?>()), Times.Never);
         }
     }
 }

--- a/src/GistGet.Test/GistGet/Infrastructure/WinGetPassthroughRunnerTests.cs
+++ b/src/GistGet.Test/GistGet/Infrastructure/WinGetPassthroughRunnerTests.cs
@@ -1,0 +1,98 @@
+using System.Diagnostics;
+using GistGet.Infrastructure.Diagnostics;
+using Moq;
+using Shouldly;
+
+namespace GistGet.Infrastructure.Diagnostics;
+
+public class WinGetPassthroughRunnerTests
+{
+    [Fact]
+    public async Task RunAsync_UsesWingetFromPathAndPassesArguments()
+    {
+        // -------------------------------------------------------------------
+        // Arrange
+        // -------------------------------------------------------------------
+        var tempDir = Directory.CreateTempSubdirectory();
+        var wingetPath = Path.Combine(tempDir.FullName, "winget.exe");
+        File.WriteAllText(wingetPath, string.Empty);
+
+        var originalPath = Environment.GetEnvironmentVariable("PATH");
+        Environment.SetEnvironmentVariable("PATH", $"{tempDir.FullName}{Path.PathSeparator}{originalPath}");
+
+        var processRunner = new Mock<IProcessRunner>();
+        ProcessStartInfo? captured = null;
+        processRunner
+            .Setup(x => x.RunAsync(It.IsAny<ProcessStartInfo>()))
+            .Callback<ProcessStartInfo>(info => captured = info)
+            .ReturnsAsync(27);
+
+        var target = new WinGetPassthroughRunner(processRunner.Object);
+
+        try
+        {
+            // -------------------------------------------------------------------
+            // Act
+            // -------------------------------------------------------------------
+            var exitCode = await target.RunAsync(new[] { "install", "Test.Package" });
+
+            // -------------------------------------------------------------------
+            // Assert
+            // -------------------------------------------------------------------
+            exitCode.ShouldBe(27);
+            captured.ShouldNotBeNull();
+            captured!.FileName.ShouldBe(wingetPath);
+            captured.ArgumentList.ShouldBe(["install", "Test.Package"]);
+            captured.UseShellExecute.ShouldBeFalse();
+            captured.CreateNoWindow.ShouldBeFalse();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("PATH", originalPath);
+            tempDir.Delete(true);
+        }
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenWingetNotInPath_UsesLocalAppDataFallback()
+    {
+        // -------------------------------------------------------------------
+        // Arrange
+        // -------------------------------------------------------------------
+        var tempDir = Directory.CreateTempSubdirectory();
+        var originalPath = Environment.GetEnvironmentVariable("PATH");
+        var originalLocalAppData = Environment.GetEnvironmentVariable("LOCALAPPDATA");
+        Environment.SetEnvironmentVariable("PATH", tempDir.FullName);
+        Environment.SetEnvironmentVariable("LOCALAPPDATA", tempDir.FullName);
+
+        var processRunner = new Mock<IProcessRunner>();
+        ProcessStartInfo? captured = null;
+        processRunner
+            .Setup(x => x.RunAsync(It.IsAny<ProcessStartInfo>()))
+            .Callback<ProcessStartInfo>(info => captured = info)
+            .ReturnsAsync(0);
+
+        var target = new WinGetPassthroughRunner(processRunner.Object);
+
+        try
+        {
+            // -------------------------------------------------------------------
+            // Act
+            // -------------------------------------------------------------------
+            var exitCode = await target.RunAsync(Array.Empty<string>());
+
+            // -------------------------------------------------------------------
+            // Assert
+            // -------------------------------------------------------------------
+            exitCode.ShouldBe(0);
+            captured.ShouldNotBeNull();
+            captured!.FileName.ShouldBe(Path.Combine(tempDir.FullName, "Microsoft", "WindowsApps", "winget.exe"));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("PATH", originalPath);
+            Environment.SetEnvironmentVariable("LOCALAPPDATA", originalLocalAppData);
+            tempDir.Delete(true);
+        }
+    }
+}

--- a/src/GistGet.Test/GistGet/Presentation/CommandBuilderTests.cs
+++ b/src/GistGet.Test/GistGet/Presentation/CommandBuilderTests.cs
@@ -1,0 +1,621 @@
+using System.CommandLine;
+using Moq;
+using Shouldly;
+using Spectre.Console;
+
+namespace GistGet.Presentation;
+
+[CollectionDefinition("AnsiConsole collection", DisableParallelization = true)]
+public class AnsiConsoleCollection : ICollectionFixture<AnsiConsoleFixture>
+{
+}
+
+public class AnsiConsoleFixture
+{
+}
+
+[Collection("AnsiConsole collection")]
+public class CommandBuilderTests
+{
+    protected readonly Mock<IGistGetService> GistGetServiceMock = new();
+
+    protected CommandBuilder CreateTarget()
+    {
+        return new CommandBuilder(GistGetServiceMock.Object);
+    }
+
+    public class Build : CommandBuilderTests
+    {
+        [Fact]
+        public void RegistersTopLevelCommands()
+        {
+            // -------------------------------------------------------------------
+            // Arrange
+            // -------------------------------------------------------------------
+            var target = CreateTarget();
+
+            // -------------------------------------------------------------------
+            // Act
+            // -------------------------------------------------------------------
+            var root = target.Build();
+            var names = root.Subcommands.Select(cmd => cmd.Name).ToList();
+            var expected = new[]
+            {
+                "sync", "export", "import", "auth", "install", "uninstall", "upgrade", "pin",
+                "list", "search", "show", "source", "settings", "features", "hash", "validate",
+                "configure", "download", "repair", "dscv3", "mcp"
+            };
+
+            // -------------------------------------------------------------------
+            // Assert
+            // -------------------------------------------------------------------
+            foreach (var command in expected)
+            {
+                names.ShouldContain(command);
+            }
+        }
+    }
+
+    public class SyncCommand : CommandBuilderTests
+    {
+        [Fact]
+        public async Task WithChanges_PrintsSummaryAndCallsService()
+        {
+            // -------------------------------------------------------------------
+            // Arrange
+            // -------------------------------------------------------------------
+            var target = CreateTarget();
+            var root = target.Build();
+            var result = new SyncResult
+            {
+                Installed = { new GistGetPackage { Id = "Package.A" } },
+                Uninstalled = { new GistGetPackage { Id = "Package.B" } },
+                PinUpdated = { new GistGetPackage { Id = "Package.C", Pin = "1.2.3" } },
+                PinRemoved = { new GistGetPackage { Id = "Package.D" } }
+            };
+
+            GistGetServiceMock
+                .Setup(x => x.SyncAsync("https://example.com/gist", "local.yaml"))
+                .ReturnsAsync(result);
+
+            // -------------------------------------------------------------------
+            // Act
+            // -------------------------------------------------------------------
+            AnsiConsole.Record();
+            var exitCode = await root.InvokeAsync("sync --url https://example.com/gist --file local.yaml");
+            var output = AnsiConsole.ExportText();
+
+            // -------------------------------------------------------------------
+            // Assert
+            // -------------------------------------------------------------------
+            exitCode.ShouldBe(0);
+            GistGetServiceMock.Verify(x => x.SyncAsync("https://example.com/gist", "local.yaml"), Times.Once);
+            output.ShouldContain("Installed 1 package");
+            output.ShouldContain("Uninstalled 1 package");
+            output.ShouldContain("Updated pin for 1 package");
+            output.ShouldContain("Removed pin for 1 package");
+            output.ShouldContain("Sync completed successfully.");
+        }
+
+        [Fact]
+        public async Task WithFailures_PrintsErrorsWithoutSuccessMessage()
+        {
+            // -------------------------------------------------------------------
+            // Arrange
+            // -------------------------------------------------------------------
+            var target = CreateTarget();
+            var root = target.Build();
+            var result = new SyncResult
+            {
+                Failed = { new GistGetPackage { Id = "Broken.Package" } },
+                Errors = { "network issue" }
+            };
+
+            GistGetServiceMock
+                .Setup(x => x.SyncAsync(null, null))
+                .ReturnsAsync(result);
+
+            // -------------------------------------------------------------------
+            // Act
+            // -------------------------------------------------------------------
+            AnsiConsole.Record();
+            var exitCode = await root.InvokeAsync("sync");
+            var output = AnsiConsole.ExportText();
+
+            // -------------------------------------------------------------------
+            // Assert
+            // -------------------------------------------------------------------
+            exitCode.ShouldBe(0);
+            output.ShouldContain("Failed 1 package");
+            output.ShouldContain("Errors:");
+            output.ShouldContain("network issue");
+            output.ShouldNotContain("Sync completed successfully.");
+        }
+
+        [Fact]
+        public async Task AlreadyInSync_PrintsNoChangesMessage()
+        {
+            // -------------------------------------------------------------------
+            // Arrange
+            // -------------------------------------------------------------------
+            var target = CreateTarget();
+            var root = target.Build();
+            var result = new SyncResult();
+
+            GistGetServiceMock
+                .Setup(x => x.SyncAsync(null, null))
+                .ReturnsAsync(result);
+
+            // -------------------------------------------------------------------
+            // Act
+            // -------------------------------------------------------------------
+            AnsiConsole.Record();
+            var exitCode = await root.InvokeAsync("sync");
+            var output = AnsiConsole.ExportText();
+
+            // -------------------------------------------------------------------
+            // Assert
+            // -------------------------------------------------------------------
+            exitCode.ShouldBe(0);
+            output.ShouldContain("Already in sync. No changes needed.");
+        }
+    }
+
+    public class ExportCommand : CommandBuilderTests
+    {
+        [Fact]
+        public async Task WithOutputPath_CallsExportWithPath()
+        {
+            // -------------------------------------------------------------------
+            // Arrange
+            // -------------------------------------------------------------------
+            var target = CreateTarget();
+            var root = target.Build();
+
+            // -------------------------------------------------------------------
+            // Act
+            // -------------------------------------------------------------------
+            var exitCode = await root.InvokeAsync("export --output exported.yaml");
+
+            // -------------------------------------------------------------------
+            // Assert
+            // -------------------------------------------------------------------
+            exitCode.ShouldBe(0);
+            GistGetServiceMock.Verify(x => x.ExportAsync("exported.yaml"), Times.Once);
+        }
+    }
+
+    public class ImportCommand : CommandBuilderTests
+    {
+        [Fact]
+        public async Task WithFileArgument_CallsImport()
+        {
+            // -------------------------------------------------------------------
+            // Arrange
+            // -------------------------------------------------------------------
+            var target = CreateTarget();
+            var root = target.Build();
+
+            // -------------------------------------------------------------------
+            // Act
+            // -------------------------------------------------------------------
+            var exitCode = await root.InvokeAsync("import packages.yaml");
+
+            // -------------------------------------------------------------------
+            // Assert
+            // -------------------------------------------------------------------
+            exitCode.ShouldBe(0);
+            GistGetServiceMock.Verify(x => x.ImportAsync("packages.yaml"), Times.Once);
+        }
+    }
+
+    public class AuthCommands : CommandBuilderTests
+    {
+        [Fact]
+        public async Task LoginLogoutStatus_CallCorrespondingServiceMethods()
+        {
+            // -------------------------------------------------------------------
+            // Arrange
+            // -------------------------------------------------------------------
+            var target = CreateTarget();
+            var root = target.Build();
+
+            // -------------------------------------------------------------------
+            // Act
+            // -------------------------------------------------------------------
+            await root.InvokeAsync("auth login");
+            await root.InvokeAsync("auth status");
+            await root.InvokeAsync("auth logout");
+
+            // -------------------------------------------------------------------
+            // Assert
+            // -------------------------------------------------------------------
+            GistGetServiceMock.Verify(x => x.AuthLoginAsync(), Times.Once);
+            GistGetServiceMock.Verify(x => x.AuthStatusAsync(), Times.Once);
+            GistGetServiceMock.Verify(x => x.AuthLogout(), Times.Once);
+        }
+    }
+
+    public class InstallCommand : CommandBuilderTests
+    {
+        [Fact]
+        public async Task WithAllOptions_PassesMappedInstallOptions()
+        {
+            // -------------------------------------------------------------------
+            // Arrange
+            // -------------------------------------------------------------------
+            var target = CreateTarget();
+            var root = target.Build();
+            GistGetServiceMock
+                .Setup(x => x.InstallAndSaveAsync(It.IsAny<InstallOptions>()))
+                .ReturnsAsync(5);
+
+            var command = string.Join(" ", new[]
+            {
+                "install --id Test.Package",
+                "--version 1.2.3",
+                "--scope user",
+                "--architecture x64",
+                "--location \"C:/Apps\"",
+                "--interactive",
+                "--silent",
+                "--log \"C:/logs/app.log\"",
+                "--override \"--custom\"",
+                "--force",
+                "--skip-dependencies",
+                "--header \"X-Test:1\"",
+                "--installer-type msi",
+                "--custom \"--xyz\"",
+                "--locale ja-JP",
+                "--accept-package-agreements",
+                "--accept-source-agreements",
+                "--ignore-security-hash"
+            });
+
+            // -------------------------------------------------------------------
+            // Act
+            // -------------------------------------------------------------------
+            var exitCode = await root.InvokeAsync(command);
+
+            // -------------------------------------------------------------------
+            // Assert
+            // -------------------------------------------------------------------
+            exitCode.ShouldBe(5);
+            GistGetServiceMock.Verify(x => x.InstallAndSaveAsync(It.Is<InstallOptions>(o =>
+                o.Id == "Test.Package" &&
+                o.Version == "1.2.3" &&
+                o.Scope == "user" &&
+                o.Architecture == "x64" &&
+                o.Location == "C:/Apps" &&
+                o.Interactive &&
+                o.Silent &&
+                o.Log == "C:/logs/app.log" &&
+                o.Override == "--custom" &&
+                o.Force &&
+                o.SkipDependencies &&
+                o.Header == "X-Test:1" &&
+                o.InstallerType == "msi" &&
+                o.Custom == "--xyz" &&
+                o.Locale == "ja-JP" &&
+                o.AcceptPackageAgreements &&
+                o.AcceptSourceAgreements &&
+                o.AllowHashMismatch
+            )), Times.Once);
+        }
+
+        [Fact]
+        public async Task WithoutId_PrintsErrorAndSkipsInstall()
+        {
+            // -------------------------------------------------------------------
+            // Arrange
+            // -------------------------------------------------------------------
+            var target = CreateTarget();
+            var root = target.Build();
+
+            // -------------------------------------------------------------------
+            // Act
+            // -------------------------------------------------------------------
+            AnsiConsole.Record();
+            var exitCode = await root.InvokeAsync("install --id \"\"");
+            var output = AnsiConsole.ExportText();
+
+            // -------------------------------------------------------------------
+            // Assert
+            // -------------------------------------------------------------------
+            exitCode.ShouldBe(0);
+            GistGetServiceMock.Verify(x => x.InstallAndSaveAsync(It.IsAny<InstallOptions>()), Times.Never);
+            output.ShouldContain("Package ID is required.");
+        }
+    }
+
+    public class UninstallCommand : CommandBuilderTests
+    {
+        [Fact]
+        public async Task WithOptions_PassesMappedUninstallOptions()
+        {
+            // -------------------------------------------------------------------
+            // Arrange
+            // -------------------------------------------------------------------
+            var target = CreateTarget();
+            var root = target.Build();
+            GistGetServiceMock
+                .Setup(x => x.UninstallAndSaveAsync(It.IsAny<UninstallOptions>()))
+                .ReturnsAsync(3);
+
+            // -------------------------------------------------------------------
+            // Act
+            // -------------------------------------------------------------------
+            var exitCode = await root.InvokeAsync("uninstall --id Test.Package --scope machine --interactive --silent --force");
+
+            // -------------------------------------------------------------------
+            // Assert
+            // -------------------------------------------------------------------
+            exitCode.ShouldBe(3);
+            GistGetServiceMock.Verify(x => x.UninstallAndSaveAsync(It.Is<UninstallOptions>(o =>
+                o.Id == "Test.Package" &&
+                o.Scope == "machine" &&
+                o.Interactive &&
+                o.Silent &&
+                o.Force
+            )), Times.Once);
+        }
+
+        [Fact]
+        public async Task WithoutId_PrintsErrorAndSkipsUninstall()
+        {
+            // -------------------------------------------------------------------
+            // Arrange
+            // -------------------------------------------------------------------
+            var target = CreateTarget();
+            var root = target.Build();
+
+            // -------------------------------------------------------------------
+            // Act
+            // -------------------------------------------------------------------
+            AnsiConsole.Record();
+            var exitCode = await root.InvokeAsync("uninstall --id \"\"");
+            var output = AnsiConsole.ExportText();
+
+            // -------------------------------------------------------------------
+            // Assert
+            // -------------------------------------------------------------------
+            exitCode.ShouldBe(0);
+            GistGetServiceMock.Verify(x => x.UninstallAndSaveAsync(It.IsAny<UninstallOptions>()), Times.Never);
+            output.ShouldContain("Package ID is required.");
+        }
+    }
+
+    public class UpgradeCommand : CommandBuilderTests
+    {
+        [Fact]
+        public async Task WithId_PassesUpgradeOptions()
+        {
+            // -------------------------------------------------------------------
+            // Arrange
+            // -------------------------------------------------------------------
+            var target = CreateTarget();
+            var root = target.Build();
+            GistGetServiceMock
+                .Setup(x => x.UpgradeAndSaveAsync(It.IsAny<UpgradeOptions>()))
+                .ReturnsAsync(7);
+
+            var command = string.Join(" ", new[]
+            {
+                "upgrade --id Test.Package",
+                "--version 2.0.0",
+                "--scope machine",
+                "--architecture arm64",
+                "--location \"D:/Apps\"",
+                "--interactive",
+                "--silent",
+                "--log \"D:/logs/app.log\"",
+                "--override \"--ovr\"",
+                "--force",
+                "--skip-dependencies",
+                "--header \"X-Upgrade:1\"",
+                "--installer-type exe",
+                "--custom \"--arg\"",
+                "--locale en-US",
+                "--accept-package-agreements",
+                "--accept-source-agreements",
+                "--ignore-security-hash"
+            });
+
+            // -------------------------------------------------------------------
+            // Act
+            // -------------------------------------------------------------------
+            var exitCode = await root.InvokeAsync(command);
+
+            // -------------------------------------------------------------------
+            // Assert
+            // -------------------------------------------------------------------
+            exitCode.ShouldBe(7);
+            GistGetServiceMock.Verify(x => x.UpgradeAndSaveAsync(It.Is<UpgradeOptions>(o =>
+                o.Id == "Test.Package" &&
+                o.Version == "2.0.0" &&
+                o.Scope == "machine" &&
+                o.Architecture == "arm64" &&
+                o.Location == "D:/Apps" &&
+                o.Interactive &&
+                o.Silent &&
+                o.Log == "D:/logs/app.log" &&
+                o.Override == "--ovr" &&
+                o.Force &&
+                o.SkipDependencies &&
+                o.Header == "X-Upgrade:1" &&
+                o.InstallerType == "exe" &&
+                o.Custom == "--arg" &&
+                o.Locale == "en-US" &&
+                o.AcceptPackageAgreements &&
+                o.AcceptSourceAgreements &&
+                o.AllowHashMismatch
+            )), Times.Once);
+        }
+
+        [Fact]
+        public async Task WithoutId_PassesThroughToWinget()
+        {
+            // -------------------------------------------------------------------
+            // Arrange
+            // -------------------------------------------------------------------
+            var target = CreateTarget();
+            var root = target.Build();
+
+            GistGetServiceMock
+                .Setup(x => x.RunPassthroughAsync("upgrade", It.IsAny<string[]>()))
+                .ReturnsAsync(11);
+
+            // -------------------------------------------------------------------
+            // Act
+            // -------------------------------------------------------------------
+            var exitCode = await root.InvokeAsync("upgrade");
+
+            // -------------------------------------------------------------------
+            // Assert
+            // -------------------------------------------------------------------
+            exitCode.ShouldBe(11);
+            GistGetServiceMock.Verify(x => x.RunPassthroughAsync("upgrade", It.Is<string[]>(args =>
+                args.Length == 0
+            )), Times.Once);
+            GistGetServiceMock.Verify(x => x.UpgradeAndSaveAsync(It.IsAny<UpgradeOptions>()), Times.Never);
+        }
+    }
+
+    public class PinCommand : CommandBuilderTests
+    {
+        [Fact]
+        public async Task Add_WithGatingPinType_PassesPinType()
+        {
+            // -------------------------------------------------------------------
+            // Arrange
+            // -------------------------------------------------------------------
+            var target = CreateTarget();
+            var root = target.Build();
+
+            // -------------------------------------------------------------------
+            // Act
+            // -------------------------------------------------------------------
+            var exitCode = await root.InvokeAsync("pin add Test.Package --version 1.2.3 --gating --force");
+
+            // -------------------------------------------------------------------
+            // Assert
+            // -------------------------------------------------------------------
+            exitCode.ShouldBe(0);
+            GistGetServiceMock.Verify(x => x.PinAddAndSaveAsync("Test.Package", "1.2.3", "gating", true), Times.Once);
+        }
+
+        [Fact]
+        public async Task Add_WithoutPinType_UsesNull()
+        {
+            // -------------------------------------------------------------------
+            // Arrange
+            // -------------------------------------------------------------------
+            var target = CreateTarget();
+            var root = target.Build();
+
+            // -------------------------------------------------------------------
+            // Act
+            // -------------------------------------------------------------------
+            var exitCode = await root.InvokeAsync("pin add Sample.Package --version 9.9.9");
+
+            // -------------------------------------------------------------------
+            // Assert
+            // -------------------------------------------------------------------
+            exitCode.ShouldBe(0);
+            GistGetServiceMock.Verify(x => x.PinAddAndSaveAsync("Sample.Package", "9.9.9", null, false), Times.Once);
+        }
+
+        [Fact]
+        public async Task Remove_CallsPinRemove()
+        {
+            // -------------------------------------------------------------------
+            // Arrange
+            // -------------------------------------------------------------------
+            var target = CreateTarget();
+            var root = target.Build();
+
+            // -------------------------------------------------------------------
+            // Act
+            // -------------------------------------------------------------------
+            var exitCode = await root.InvokeAsync("pin remove Old.Package");
+
+            // -------------------------------------------------------------------
+            // Assert
+            // -------------------------------------------------------------------
+            exitCode.ShouldBe(0);
+            GistGetServiceMock.Verify(x => x.PinRemoveAndSaveAsync("Old.Package"), Times.Once);
+        }
+
+        [Fact]
+        public async Task List_ForwardsArgumentsToWinget()
+        {
+            // -------------------------------------------------------------------
+            // Arrange
+            // -------------------------------------------------------------------
+            var target = CreateTarget();
+            var root = target.Build();
+
+            // -------------------------------------------------------------------
+            // Act
+            // -------------------------------------------------------------------
+            var exitCode = await root.InvokeAsync("pin list --source msstore");
+
+            // -------------------------------------------------------------------
+            // Assert
+            // -------------------------------------------------------------------
+            exitCode.ShouldBe(0);
+            GistGetServiceMock.Verify(x => x.RunPassthroughAsync("pin", It.Is<string[]>(args =>
+                args.SequenceEqual(new[] { "list", "--source", "msstore" })
+            )), Times.Once);
+        }
+
+        [Fact]
+        public async Task Reset_ForwardsArgumentsToWinget()
+        {
+            // -------------------------------------------------------------------
+            // Arrange
+            // -------------------------------------------------------------------
+            var target = CreateTarget();
+            var root = target.Build();
+
+            // -------------------------------------------------------------------
+            // Act
+            // -------------------------------------------------------------------
+            var exitCode = await root.InvokeAsync("pin reset --force");
+
+            // -------------------------------------------------------------------
+            // Assert
+            // -------------------------------------------------------------------
+            exitCode.ShouldBe(0);
+            GistGetServiceMock.Verify(x => x.RunPassthroughAsync("pin", It.Is<string[]>(args =>
+                args.SequenceEqual(new[] { "reset", "--force" })
+            )), Times.Once);
+        }
+    }
+
+    public class WingetPassthroughCommands : CommandBuilderTests
+    {
+        [Fact]
+        public async Task List_ForwardsToRunner()
+        {
+            // -------------------------------------------------------------------
+            // Arrange
+            // -------------------------------------------------------------------
+            var target = CreateTarget();
+            var root = target.Build();
+
+            // -------------------------------------------------------------------
+            // Act
+            // -------------------------------------------------------------------
+            var exitCode = await root.InvokeAsync("list --source msstore");
+
+            // -------------------------------------------------------------------
+            // Assert
+            // -------------------------------------------------------------------
+            exitCode.ShouldBe(0);
+            GistGetServiceMock.Verify(x => x.RunPassthroughAsync("list", It.Is<string[]>(args =>
+                args.SequenceEqual(new[] { "--source", "msstore" })
+            )), Times.Once);
+        }
+    }
+}

--- a/src/GistGet.Test/GistGet/Presentation/ConsoleServiceTests.cs
+++ b/src/GistGet.Test/GistGet/Presentation/ConsoleServiceTests.cs
@@ -1,0 +1,132 @@
+using System.Diagnostics;
+using GistGet.Infrastructure.Diagnostics;
+using Moq;
+using Shouldly;
+
+namespace GistGet.Presentation;
+
+[Collection("AnsiConsole collection")]
+public class ConsoleServiceTests
+{
+    [Fact]
+    public void WriteInfo_WritesMessageToConsole()
+    {
+        // -------------------------------------------------------------------
+        // Arrange
+        // -------------------------------------------------------------------
+        var writer = new StringWriter();
+        var originalOut = Console.Out;
+        Console.SetOut(writer);
+        var processRunner = new Mock<IProcessRunner>();
+        var target = new ConsoleService(processRunner.Object);
+
+        try
+        {
+            // -------------------------------------------------------------------
+            // Act
+            // -------------------------------------------------------------------
+            target.WriteInfo("hello");
+
+            // -------------------------------------------------------------------
+            // Assert
+            // -------------------------------------------------------------------
+            writer.ToString().ShouldContain("hello");
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+    }
+
+    [Fact]
+    public void WriteWarning_PrefixesMessageWithIndicator()
+    {
+        // -------------------------------------------------------------------
+        // Arrange
+        // -------------------------------------------------------------------
+        var writer = new StringWriter();
+        var originalOut = Console.Out;
+        Console.SetOut(writer);
+        var processRunner = new Mock<IProcessRunner>();
+        var target = new ConsoleService(processRunner.Object);
+
+        try
+        {
+            // -------------------------------------------------------------------
+            // Act
+            // -------------------------------------------------------------------
+            target.WriteWarning("be careful");
+
+            // -------------------------------------------------------------------
+            // Assert
+            // -------------------------------------------------------------------
+            writer.ToString().ShouldContain("! be careful");
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+    }
+
+    [Fact]
+    public void ReadLine_ReturnsInputFromConsole()
+    {
+        // -------------------------------------------------------------------
+        // Arrange
+        // -------------------------------------------------------------------
+        var input = new StringReader("user input\n");
+        var originalIn = Console.In;
+        Console.SetIn(input);
+        var processRunner = new Mock<IProcessRunner>();
+        var target = new ConsoleService(processRunner.Object);
+
+        try
+        {
+            // -------------------------------------------------------------------
+            // Act
+            // -------------------------------------------------------------------
+            var result = target.ReadLine();
+
+            // -------------------------------------------------------------------
+            // Assert
+            // -------------------------------------------------------------------
+            result.ShouldBe("user input");
+        }
+        finally
+        {
+            Console.SetIn(originalIn);
+        }
+    }
+
+    [Fact]
+    public void SetClipboard_UsesPowershellAndEscapesText()
+    {
+        // -------------------------------------------------------------------
+        // Arrange
+        // -------------------------------------------------------------------
+        var processRunner = new Mock<IProcessRunner>();
+        ProcessStartInfo? captured = null;
+        processRunner
+            .Setup(x => x.RunAsync(It.IsAny<ProcessStartInfo>()))
+            .Callback<ProcessStartInfo>(info => captured = info)
+            .ReturnsAsync(0);
+
+        var target = new ConsoleService(processRunner.Object);
+
+        // -------------------------------------------------------------------
+        // Act
+        // -------------------------------------------------------------------
+        target.SetClipboard("te'st");
+
+        // -------------------------------------------------------------------
+        // Assert
+        // -------------------------------------------------------------------
+        captured.ShouldNotBeNull();
+        captured!.FileName.ShouldBe("powershell");
+        captured.Arguments.ShouldContain("te''st");
+        captured.UseShellExecute.ShouldBeFalse();
+        captured.CreateNoWindow.ShouldBeTrue();
+        captured.RedirectStandardOutput.ShouldBeTrue();
+        captured.RedirectStandardError.ShouldBeTrue();
+    }
+}

--- a/src/GistGet/GistGet/Infrastructure/Diagnostics/IProcessRunner.cs
+++ b/src/GistGet/GistGet/Infrastructure/Diagnostics/IProcessRunner.cs
@@ -1,0 +1,8 @@
+using System.Diagnostics;
+
+namespace GistGet.Infrastructure.Diagnostics;
+
+public interface IProcessRunner
+{
+    Task<int> RunAsync(ProcessStartInfo startInfo);
+}

--- a/src/GistGet/GistGet/Infrastructure/Diagnostics/ProcessRunner.cs
+++ b/src/GistGet/GistGet/Infrastructure/Diagnostics/ProcessRunner.cs
@@ -1,0 +1,14 @@
+using System.Diagnostics;
+
+namespace GistGet.Infrastructure.Diagnostics;
+
+public class ProcessRunner : IProcessRunner
+{
+    public async Task<int> RunAsync(ProcessStartInfo startInfo)
+    {
+        using var process = new Process { StartInfo = startInfo };
+        process.Start();
+        await process.WaitForExitAsync();
+        return process.ExitCode;
+    }
+}

--- a/src/GistGet/GistGet/Infrastructure/GitHubClientFactory.cs
+++ b/src/GistGet/GistGet/Infrastructure/GitHubClientFactory.cs
@@ -1,0 +1,67 @@
+using Octokit;
+
+namespace GistGet.Infrastructure;
+
+public class GitHubClientFactory : IGitHubClientFactory
+{
+    public IGitHubClientWrapper Create(string? token)
+    {
+        var client = new GitHubClient(new ProductHeaderValue(Constants.ProductHeader));
+        if (!string.IsNullOrWhiteSpace(token))
+        {
+            client.Credentials = new Credentials(token);
+        }
+
+        return new OctokitGitHubClientWrapper(client);
+    }
+
+    private sealed class OctokitGitHubClientWrapper : IGitHubClientWrapper
+    {
+        private readonly GitHubClient _client;
+
+        public OctokitGitHubClientWrapper(GitHubClient client)
+        {
+            _client = client;
+        }
+
+        public Task<OauthDeviceFlowResponse> InitiateDeviceFlowAsync(OauthDeviceFlowRequest request)
+        {
+            return _client.Oauth.InitiateDeviceFlow(request);
+        }
+
+        public Task<OauthToken> CreateAccessTokenForDeviceFlowAsync(string clientId, OauthDeviceFlowResponse response)
+        {
+            return _client.Oauth.CreateAccessTokenForDeviceFlow(clientId, response);
+        }
+
+        public Task<User> GetCurrentUserAsync()
+        {
+            return _client.User.Current();
+        }
+
+        public ApiInfo? GetLastApiInfo()
+        {
+            return _client.GetLastApiInfo();
+        }
+
+        public Task<IReadOnlyList<Gist>> GetAllGistsAsync()
+        {
+            return _client.Gist.GetAll();
+        }
+
+        public Task<Gist> GetGistAsync(string id)
+        {
+            return _client.Gist.Get(id);
+        }
+
+        public Task<Gist> EditGistAsync(string id, GistUpdate update)
+        {
+            return _client.Gist.Edit(id, update);
+        }
+
+        public Task<Gist> CreateGistAsync(NewGist gist)
+        {
+            return _client.Gist.Create(gist);
+        }
+    }
+}

--- a/src/GistGet/GistGet/Infrastructure/IGitHubClientFactory.cs
+++ b/src/GistGet/GistGet/Infrastructure/IGitHubClientFactory.cs
@@ -1,0 +1,20 @@
+using Octokit;
+
+namespace GistGet.Infrastructure;
+
+public interface IGitHubClientFactory
+{
+    IGitHubClientWrapper Create(string? token);
+}
+
+public interface IGitHubClientWrapper
+{
+    Task<OauthDeviceFlowResponse> InitiateDeviceFlowAsync(OauthDeviceFlowRequest request);
+    Task<OauthToken> CreateAccessTokenForDeviceFlowAsync(string clientId, OauthDeviceFlowResponse response);
+    Task<User> GetCurrentUserAsync();
+    ApiInfo? GetLastApiInfo();
+    Task<IReadOnlyList<Gist>> GetAllGistsAsync();
+    Task<Gist> GetGistAsync(string id);
+    Task<Gist> EditGistAsync(string id, GistUpdate update);
+    Task<Gist> CreateGistAsync(NewGist gist);
+}

--- a/src/GistGet/GistGet/Infrastructure/WinGetPassthroughRunner.cs
+++ b/src/GistGet/GistGet/Infrastructure/WinGetPassthroughRunner.cs
@@ -4,6 +4,13 @@ namespace GistGet.Infrastructure.Diagnostics;
 
 public class WinGetPassthroughRunner : IWinGetPassthroughRunner
 {
+    private readonly IProcessRunner _processRunner;
+
+    public WinGetPassthroughRunner(IProcessRunner processRunner)
+    {
+        _processRunner = processRunner;
+    }
+
     public async Task<int> RunAsync(string[] args)
     {
         var startInfo = new ProcessStartInfo
@@ -21,10 +28,7 @@ public class WinGetPassthroughRunner : IWinGetPassthroughRunner
             startInfo.ArgumentList.Add(arg);
         }
 
-        using var process = new Process { StartInfo = startInfo };
-        process.Start();
-        await process.WaitForExitAsync();
-        return process.ExitCode;
+        return await _processRunner.RunAsync(startInfo);
     }
 
     private string ResolveWinGetPath()

--- a/src/GistGet/Program.cs
+++ b/src/GistGet/Program.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 ServiceCollection services = new();
 
 // GistGet
+services.AddSingleton<IGitHubClientFactory, GitHubClientFactory>();
 services.AddTransient<IGitHubService, GitHubService>();
 services.AddTransient<IGistGetService, GistGetService>();
 
@@ -17,6 +18,7 @@ services.AddTransient<IConsoleService, ConsoleService>();
 
 // Infrastructure
 services.AddTransient<ICredentialService, CredentialService>();
+services.AddSingleton<IProcessRunner, ProcessRunner>();
 services.AddTransient<IWinGetPassthroughRunner, WinGetPassthroughRunner>();
 services.AddTransient<IWinGetService, WinGetService>();
 services.AddTransient<IWinGetArgumentBuilder, WinGetArgumentBuilder>();


### PR DESCRIPTION
## 概要
- coverlet.runsettings と Analyze-Coverage.ps1 を追加し、生成コードやエントリーポイントを除外して解析を簡素化
- Run-Tests.ps1 にカバレッジ閾値(95%)と集計処理を組み込み、x64指定で安定化
- GitHubService/Console/WinGet周辺のテストを拡充し、ProcessRunner抽象化とGitHubClientFactory導入でテスト容易性を向上
- GitHubServiceのデバイスフローをテスト可能にし、各種分岐のカバレッジを追加
- WinGetパススルーの動作とコンソール出力の検証を追加

## テスト
- .\scripts\Run-Tests.ps1