### PR TITLE
chore: add minimal English documentation

### DIFF
--- a/src/GistGet/GistGet/Constants.cs
+++ b/src/GistGet/GistGet/Constants.cs
@@ -1,5 +1,10 @@
+// Shared constant values used across GistGet.
+
 namespace GistGet;
 
+/// <summary>
+/// Defines constant values for default names, paths, and settings.
+/// </summary>
 public static class Constants
 {
     public const string ProductHeader = "GistGet";

--- a/src/GistGet/GistGet/Credential.cs
+++ b/src/GistGet/GistGet/Credential.cs
@@ -1,3 +1,8 @@
+// Authentication credential model for GitHub access.
+
 namespace GistGet;
 
+/// <summary>
+/// Represents the GitHub credential data used by the application.
+/// </summary>
 public record Credential(string Username, string Token);

--- a/src/GistGet/GistGet/GistGetPackage.cs
+++ b/src/GistGet/GistGet/GistGetPackage.cs
@@ -1,8 +1,13 @@
-﻿using System.Xml.Serialization;
+﻿// Package metadata stored in and synchronized via GitHub Gist.
+
+using System.Xml.Serialization;
 using YamlDotNet.Serialization;
 
 namespace GistGet;
 
+/// <summary>
+/// Represents a package entry persisted to the GistGet manifest.
+/// </summary>
 public class GistGetPackage
 {
     [YamlIgnore]

--- a/src/GistGet/GistGet/GistGetPackageSerializer.cs
+++ b/src/GistGet/GistGet/GistGetPackageSerializer.cs
@@ -1,21 +1,18 @@
+// YAML serialization utilities for the GistGet package manifest.
+
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 
 namespace GistGet;
 
 /// <summary>
-/// GistGetPackage の YAML シリアライズ/デシリアライズを担当する静的クラス。
-/// GistGet.yaml 形式への変換と読み込みを提供します。
+/// Serializes and deserializes GistGet package manifests for storage.
 /// </summary>
 public static class GistGetPackageSerializer
 {
     /// <summary>
-    /// パッケージ一覧を YAML 形式の文字列にシリアライズします。
-    /// パッケージ ID をキーとしたマップ形式で出力されます。
+    /// Serializes packages to YAML.
     /// </summary>
-    /// <param name="packages">シリアライズするパッケージ一覧</param>
-    /// <returns>YAML 形式の文字列</returns>
-    /// <exception cref="ArgumentException">パッケージ ID が未設定の場合</exception>
     public static string Serialize(IReadOnlyList<GistGetPackage> packages)
     {
         var dict = new Dictionary<string, GistGetPackage>(StringComparer.OrdinalIgnoreCase);
@@ -26,7 +23,6 @@ public static class GistGetPackageSerializer
                 throw new ArgumentException("Package Id is required.", nameof(packages));
             }
 
-            // ID 以外のプロパティをコピー（ID は YAML キーとして使用）
             var copy = new GistGetPackage
             {
                 Version = package.Version,
@@ -65,11 +61,8 @@ public static class GistGetPackageSerializer
     }
 
     /// <summary>
-    /// YAML 形式の文字列をパッケージ一覧にデシリアライズします。
-    /// パッケージ ID は YAML のキーから設定されます。
+    /// Deserializes YAML into packages.
     /// </summary>
-    /// <param name="yaml">YAML 形式の文字列</param>
-    /// <returns>パッケージ一覧（ID 順でソート済み）</returns>
     public static IReadOnlyList<GistGetPackage> Deserialize(string yaml)
     {
         var deserializer = new DeserializerBuilder()

--- a/src/GistGet/GistGet/GistGetService.cs
+++ b/src/GistGet/GistGet/GistGetService.cs
@@ -1,32 +1,26 @@
-﻿using System;
+﻿// Core application service that orchestrates GitHub and WinGet operations.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.Extensions.Logging;
 using GistGet.Infrastructure;
 
 namespace GistGet;
 
 /// <summary>
-/// GistGetの中核サービスクラス。
-/// GitHub Gistとの同期、WinGetコマンドの実行、認証管理を統合的に提供します。
+/// Implements the main workflows for syncing, exporting, importing, and package operations.
 /// </summary>
-/// <param name="gitHubService">GitHub APIとの通信を担当するサービス</param>
-/// <param name="consoleService">コンソール出力を担当するサービス</param>
-/// <param name="credentialService">資格情報の永続化を担当するサービス</param>
-/// <param name="passthroughRunner">WinGetコマンドのパススルー実行を担当するサービス</param>
-/// <param name="winGetService">ローカルパッケージ情報の取得を担当するサービス</param>
 public class GistGetService(
     IGitHubService gitHubService,
     IConsoleService consoleService,
     ICredentialService credentialService,
     IWinGetPassthroughRunner passthroughRunner,
     IWinGetService winGetService,
-    IWinGetArgumentBuilder argumentBuilder) 
+    IWinGetArgumentBuilder argumentBuilder)
     : IGistGetService
 {
     /// <summary>
-    /// GitHubへのログイン処理を実行します。
-    /// Device Flowによる認証を行い、取得した資格情報を保存します。
+    /// Authenticates via GitHub device flow and stores the credential.
     /// </summary>
     public async Task AuthLoginAsync()
     {
@@ -35,8 +29,7 @@ public class GistGetService(
     }
 
     /// <summary>
-    /// ログアウト処理を実行します。
-    /// 保存されている資格情報を削除します。
+    /// Logs out and removes any stored credential.
     /// </summary>
     public void AuthLogout()
     {
@@ -45,57 +38,50 @@ public class GistGetService(
     }
 
     /// <summary>
-    /// 現在の認証状態を表示します。
-    /// ログイン中の場合、ユーザー名、トークン情報、スコープを表示します。
+    /// Displays the current authentication status.
     /// </summary>
     public async Task AuthStatusAsync()
     {
-        if (credentialService.TryGetCredential(out var credential))
-        {
-             try
-             {
-                 var status = await gitHubService.GetTokenStatusAsync(credential.Token);
-
-                 // セキュリティのため、トークンを部分的にマスクして表示
-                 var tokenSafeDisplay = "**********";
-                 if (!string.IsNullOrEmpty(credential.Token) && credential.Token.StartsWith("gho_"))
-                 {
-                     tokenSafeDisplay = "gho_**********";
-                 }
-                 else if (!string.IsNullOrEmpty(credential.Token) && credential.Token.Length > 4)
-                 {
-                     tokenSafeDisplay = credential.Token[..4] + "**********";
-                 }
-
-                 var scopesStr = string.Join(", ", status.Scopes.Select(s => $"'{s}'"));
-
-                 // gh auth status 形式で認証情報を出力
-                 consoleService.WriteInfo("github.com");
-                 consoleService.WriteInfo($"  ✓ Logged in to github.com account {status.Username} (keyring)");
-                 consoleService.WriteInfo("  - Active account: true");
-                 consoleService.WriteInfo("  - Git operations protocol: https");
-                 consoleService.WriteInfo($"  - Token: {tokenSafeDisplay}");
-                 consoleService.WriteInfo($"  - Token scopes: {scopesStr}");
-             }
-             catch (Exception ex)
-             {
-                 consoleService.WriteInfo($"Failed to retrieve status from GitHub: {ex.Message}");
-             }
-        }
-        else
+        if (!credentialService.TryGetCredential(out var credential))
         {
             consoleService.WriteInfo("You are not logged in.");
+            return;
+        }
+
+        try
+        {
+            var status = await gitHubService.GetTokenStatusAsync(credential.Token);
+
+            var tokenSafeDisplay = "**********";
+            if (!string.IsNullOrEmpty(credential.Token) && credential.Token.StartsWith("gho_"))
+            {
+                tokenSafeDisplay = "gho_**********";
+            }
+            else if (!string.IsNullOrEmpty(credential.Token) && credential.Token.Length > 4)
+            {
+                tokenSafeDisplay = credential.Token[..4] + "**********";
+            }
+
+            var scopesStr = string.Join(", ", status.Scopes.Select(s => $"'{s}'"));
+
+            consoleService.WriteInfo("github.com");
+            consoleService.WriteInfo($"  ✓ Logged in to github.com account {status.Username} (keyring)");
+            consoleService.WriteInfo("  - Active account: true");
+            consoleService.WriteInfo("  - Git operations protocol: https");
+            consoleService.WriteInfo($"  - Token: {tokenSafeDisplay}");
+            consoleService.WriteInfo($"  - Token scopes: {scopesStr}");
+        }
+        catch (Exception ex)
+        {
+            consoleService.WriteInfo($"Failed to retrieve status from GitHub: {ex.Message}");
         }
     }
 
     /// <summary>
-    /// パッケージをインストールし、Gistに保存します。
-    /// 認証確認、Gist取得、バージョン解決、インストール実行、Pin設定、Gist更新を行います。
+    /// Installs a package and persists it to the manifest.
     /// </summary>
-    /// <param name="options">インストールオプション</param>
     public async Task<int> InstallAndSaveAsync(InstallOptions options)
     {
-        // ステップ1: 認証状態を確認し、未認証の場合はログインを促す
         if (!credentialService.TryGetCredential(out var credential))
         {
             await AuthLoginAsync();
@@ -105,77 +91,56 @@ public class GistGetService(
             }
         }
 
-        // ステップ2: Gistから既存のパッケージ一覧を取得
-        var existingPackages = await gitHubService.GetPackagesAsync(credential.Token, Constants.DefaultGistFileName, Constants.DefaultGistDescription);
-        var existingPackage = existingPackages.FirstOrDefault(p => string.Equals(p.Id, options.Id, StringComparison.OrdinalIgnoreCase));
+        var existingPackages = await gitHubService.GetPackagesAsync(
+            credential.Token,
+            Constants.DefaultGistFileName,
+            Constants.DefaultGistDescription);
 
-        // ステップ3: Pinロジックとインストールバージョンの解決
+        var existingPackage = existingPackages.FirstOrDefault(p =>
+            string.Equals(p.Id, options.Id, StringComparison.OrdinalIgnoreCase));
+
         string? installVersion = options.Version;
         string? pinVersionToSet = null;
-        // 既存のPinTypeを継承（CLI引数で未指定の場合）
         string? pinTypeToSet = existingPackage?.PinType;
 
         if (!string.IsNullOrEmpty(options.Version))
         {
-            // CLIでバージョンが明示的に指定された場合
             installVersion = options.Version;
 
             if (existingPackage != null && !string.IsNullOrEmpty(existingPackage.Pin))
             {
-                // Gistに既存のPinがある場合、インストールバージョンに更新
                 pinVersionToSet = options.Version;
             }
         }
-        else
+        else if (existingPackage != null && !string.IsNullOrEmpty(existingPackage.Pin))
         {
-            // CLIでバージョン未指定の場合
-            if (existingPackage != null && !string.IsNullOrEmpty(existingPackage.Pin))
-            {
-                // GistのPinバージョンを使用
-                installVersion = existingPackage.Pin;
-                pinVersionToSet = existingPackage.Pin;
-            }
+            installVersion = existingPackage.Pin;
+            pinVersionToSet = existingPackage.Pin;
         }
 
-        // ステップ4: WinGet installコマンドの引数を構築
         var installArgs = argumentBuilder.BuildInstallArgs(options);
-        // Pinバージョン指定がある場合は上書き（CLIオプションのバージョンよりも優先される場合のロジックはビルダー外で制御が必要だが、
-        // 現状のGistGetServiceの実装ではinstallArgsに--versionを追加するロジックが複雑。
-        // ビルダーのBuildInstallArgsはoptions.Versionのみを見る。
-        // ここでのロジック:
-        // if (!string.IsNullOrEmpty(installVersion)) { installArgs.Add("--version"); ... }
-        // 既存のコードでは `installVersion` 変数を使っている。これは options.Version または gist.Pin から来ている。
-        // ビルダーを使うなら、options.Version を installVersion に書き換えたコピーを作るか、ビルダーに version オーバーライドを渡せるようにするか。
-        // ここは一時的に InstallOptions を複製して Version を書き換えるのが一番副作用が少ない。
-        
         if (installVersion != options.Version)
         {
             options = options with { Version = installVersion };
             installArgs = argumentBuilder.BuildInstallArgs(options);
         }
 
-
-
-        // ステップ5: WinGet installを実行
         var exitCode = await passthroughRunner.RunAsync(installArgs.ToArray());
         if (exitCode != 0)
         {
-            // インストール失敗時はGistを更新せずに終了コードを返す
             return exitCode;
         }
 
-        // ステップ6: 必要に応じてWinGet pin addを実行
         if (!string.IsNullOrEmpty(pinVersionToSet))
         {
             var pinArgs = argumentBuilder.BuildPinAddArgs(options.Id, pinVersionToSet, pinTypeToSet);
             await passthroughRunner.RunAsync(pinArgs);
         }
 
+        var newPackagesList = existingPackages
+            .Where(p => !string.Equals(p.Id, options.Id, StringComparison.OrdinalIgnoreCase))
+            .ToList();
 
-        // ステップ7: パッケージリストを更新してGistに保存
-        var newPackagesList = existingPackages.Where(p => !string.Equals(p.Id, options.Id, StringComparison.OrdinalIgnoreCase)).ToList();
-        
-        // CLI引数とGist状態をマージした新しいパッケージエントリを作成
         var versionToSave = pinVersionToSet;
         var packageToSave = new GistGetPackage
         {
@@ -183,8 +148,6 @@ public class GistGetService(
             Version = versionToSave,
             Pin = pinVersionToSet,
             PinType = pinTypeToSet,
-            
-            // CLI引数のプロパティを保存
             Silent = options.Silent,
             Interactive = options.Interactive,
             Force = options.Force,
@@ -201,21 +164,24 @@ public class GistGetService(
             Locale = options.Locale,
             AcceptPackageAgreements = options.AcceptPackageAgreements,
             AcceptSourceAgreements = options.AcceptSourceAgreements,
-            
-            // インストール直後なのでuninstallはfalse
-            Uninstall = false 
+            Uninstall = false,
         };
 
         newPackagesList.Add(packageToSave);
-        
-        await gitHubService.SavePackagesAsync(credential.Token, "", Constants.DefaultGistFileName, Constants.DefaultGistDescription, newPackagesList);
+
+        await gitHubService.SavePackagesAsync(
+            credential.Token,
+            "",
+            Constants.DefaultGistFileName,
+            Constants.DefaultGistDescription,
+            newPackagesList);
+
         return 0;
     }
 
     /// <summary>
-    /// パッケージをアンインストールし、Gistを更新します。
+    /// Uninstalls a package and updates the manifest.
     /// </summary>
-    /// <param name="options">アンインストールオプション</param>
     public async Task<int> UninstallAndSaveAsync(UninstallOptions options)
     {
         if (!credentialService.TryGetCredential(out var credential))
@@ -227,19 +193,22 @@ public class GistGetService(
             }
         }
 
-        var existingPackages = await gitHubService.GetPackagesAsync(credential.Token, Constants.DefaultGistFileName, Constants.DefaultGistDescription);
-        var targetPackage = existingPackages.FirstOrDefault(p => string.Equals(p.Id, options.Id, StringComparison.OrdinalIgnoreCase));
+        var existingPackages = await gitHubService.GetPackagesAsync(
+            credential.Token,
+            Constants.DefaultGistFileName,
+            Constants.DefaultGistDescription);
+
+        var targetPackage = existingPackages.FirstOrDefault(p =>
+            string.Equals(p.Id, options.Id, StringComparison.OrdinalIgnoreCase));
 
         var uninstallArgs = argumentBuilder.BuildUninstallArgs(options);
-        
+
         var exitCode = await passthroughRunner.RunAsync(uninstallArgs.ToArray());
         if (exitCode != 0)
         {
             return exitCode;
         }
 
-        // ローカルのpinを常に削除（Gist側のpin有無に関係なく）
-        // エラーは無視（元々pinがない場合もあるため）
         await passthroughRunner.RunAsync(new[] { "pin", "remove", "--id", options.Id });
 
         var newPackages = existingPackages
@@ -254,14 +223,19 @@ public class GistGetService(
 
         newPackages.Add(packageToSave);
 
-        await gitHubService.SavePackagesAsync(credential.Token, "", Constants.DefaultGistFileName, Constants.DefaultGistDescription, newPackages);
+        await gitHubService.SavePackagesAsync(
+            credential.Token,
+            "",
+            Constants.DefaultGistFileName,
+            Constants.DefaultGistDescription,
+            newPackages);
+
         return 0;
     }
 
     /// <summary>
-    /// パッケージをアップグレードし、Gistを更新します。
+    /// Upgrades a package and updates the manifest.
     /// </summary>
-    /// <param name="options">アップグレードオプション</param>
     public async Task<int> UpgradeAndSaveAsync(UpgradeOptions options)
     {
         if (!credentialService.TryGetCredential(out var credential))
@@ -281,8 +255,13 @@ public class GistGetService(
             return exitCode;
         }
 
-        var existingPackages = await gitHubService.GetPackagesAsync(credential.Token, Constants.DefaultGistFileName, Constants.DefaultGistDescription);
-        var existingPackage = existingPackages.FirstOrDefault(p => string.Equals(p.Id, options.Id, StringComparison.OrdinalIgnoreCase));
+        var existingPackages = await gitHubService.GetPackagesAsync(
+            credential.Token,
+            Constants.DefaultGistFileName,
+            Constants.DefaultGistDescription);
+
+        var existingPackage = existingPackages.FirstOrDefault(p =>
+            string.Equals(p.Id, options.Id, StringComparison.OrdinalIgnoreCase));
 
         var resolvedVersion = options.Version;
         var hasPin = !string.IsNullOrEmpty(existingPackage?.Pin);
@@ -331,8 +310,7 @@ public class GistGetService(
             packageToSave.PinType = null;
             packageToSave.Version = null;
         }
-        
-        // Gist保存対象のオプションを反映
+
         packageToSave.Scope = options.Scope ?? packageToSave.Scope;
         packageToSave.Architecture = options.Architecture ?? packageToSave.Architecture;
         packageToSave.Location = options.Location ?? packageToSave.Location;
@@ -349,17 +327,19 @@ public class GistGetService(
 
         newPackages.Add(packageToSave);
 
-        await gitHubService.SavePackagesAsync(credential.Token, "", Constants.DefaultGistFileName, Constants.DefaultGistDescription, newPackages);
+        await gitHubService.SavePackagesAsync(
+            credential.Token,
+            "",
+            Constants.DefaultGistFileName,
+            Constants.DefaultGistDescription,
+            newPackages);
+
         return 0;
     }
 
     /// <summary>
-    /// パッケージのPinを追加し、Gistを更新します。
+    /// Adds a pin and persists it to the manifest.
     /// </summary>
-    /// <param name="packageId">PinするパッケージのID</param>
-    /// <param name="version">Pinするバージョン</param>
-    /// <param name="pinType">Pinの種類（blocking, gating）。省略時は既存値を維持</param>
-    /// <param name="force">既存のPinを上書きする場合はtrue（デフォルトはtrue）</param>
     public async Task PinAddAndSaveAsync(string packageId, string version, string? pinType = null, bool force = false)
     {
         if (!credentialService.TryGetCredential(out var credential))
@@ -371,12 +351,15 @@ public class GistGetService(
             }
         }
 
-        var existingPackages = await gitHubService.GetPackagesAsync(credential.Token, Constants.DefaultGistFileName, Constants.DefaultGistDescription);
-        var existingPackage = existingPackages.FirstOrDefault(p => string.Equals(p.Id, packageId, StringComparison.OrdinalIgnoreCase));
+        var existingPackages = await gitHubService.GetPackagesAsync(
+            credential.Token,
+            Constants.DefaultGistFileName,
+            Constants.DefaultGistDescription);
 
-        // CLIで指定されたpinTypeがあればそれを使用、なければ既存の値を継承
+        var existingPackage = existingPackages.FirstOrDefault(p =>
+            string.Equals(p.Id, packageId, StringComparison.OrdinalIgnoreCase));
+
         var pinTypeToSet = pinType ?? existingPackage?.PinType;
-
         var pinArgs = argumentBuilder.BuildPinAddArgs(packageId, version, pinTypeToSet, force);
 
         var exitCode = await passthroughRunner.RunAsync(pinArgs.ToArray());
@@ -397,16 +380,19 @@ public class GistGetService(
 
         newPackages.Add(packageToSave);
 
-        await gitHubService.SavePackagesAsync(credential.Token, "", Constants.DefaultGistFileName, Constants.DefaultGistDescription, newPackages);
+        await gitHubService.SavePackagesAsync(
+            credential.Token,
+            "",
+            Constants.DefaultGistFileName,
+            Constants.DefaultGistDescription,
+            newPackages);
     }
 
     /// <summary>
-    /// パッケージのPinを削除し、Gistを更新します。
+    /// Removes a pin and updates the manifest.
     /// </summary>
-    /// <param name="packageId">Pin解除するパッケージのID</param>
     public async Task PinRemoveAndSaveAsync(string packageId)
     {
-        // ステップ1: 認証状態を確認し、未認証の場合はログインを促す
         if (!credentialService.TryGetCredential(out var credential))
         {
             await AuthLoginAsync();
@@ -416,47 +402,48 @@ public class GistGetService(
             }
         }
 
-        // ステップ2: Gistから既存のパッケージ一覧を取得
-        var existingPackages = await gitHubService.GetPackagesAsync(credential.Token, Constants.DefaultGistFileName, Constants.DefaultGistDescription);
-        var existingPackage = existingPackages.FirstOrDefault(p => string.Equals(p.Id, packageId, StringComparison.OrdinalIgnoreCase));
+        var existingPackages = await gitHubService.GetPackagesAsync(
+            credential.Token,
+            Constants.DefaultGistFileName,
+            Constants.DefaultGistDescription);
 
-        // ステップ3: WinGet pin removeを実行
+        var existingPackage = existingPackages.FirstOrDefault(p =>
+            string.Equals(p.Id, packageId, StringComparison.OrdinalIgnoreCase));
+
         var pinArgs = new[] { "pin", "remove", "--id", packageId };
         var exitCode = await passthroughRunner.RunAsync(pinArgs);
         if (exitCode != 0)
         {
-            // pin remove 失敗時はGistを更新せずに終了
             return;
         }
 
-        // ステップ4: パッケージリストを更新してGistに保存
         var newPackages = existingPackages
             .Where(p => !string.Equals(p.Id, packageId, StringComparison.OrdinalIgnoreCase))
             .ToList();
 
         var packageToSave = existingPackage ?? new GistGetPackage { Id = packageId };
-        // pinとpinType、versionを削除
         packageToSave.Pin = null;
         packageToSave.PinType = null;
         packageToSave.Version = null;
 
         newPackages.Add(packageToSave);
 
-        await gitHubService.SavePackagesAsync(credential.Token, "", Constants.DefaultGistFileName, Constants.DefaultGistDescription, newPackages);
+        await gitHubService.SavePackagesAsync(
+            credential.Token,
+            "",
+            Constants.DefaultGistFileName,
+            Constants.DefaultGistDescription,
+            newPackages);
     }
 
     /// <summary>
-    /// GistのpackagesとYAMLとローカル状態を同期します。
-    /// 差分を検出し、インストール/アンインストール/pin設定を実行します。
+    /// Synchronizes the manifest with local state.
     /// </summary>
-    /// <param name="url">同期元の URL（省略時は認証ユーザーの Gist）</param>
-    /// <returns>同期結果（インストール/アンインストール/失敗したパッケージ一覧）</returns>
     public async Task<SyncResult> SyncAsync(string? url = null, string? filePath = null)
     {
         var result = new SyncResult();
-        
+
         IReadOnlyList<GistGetPackage> gistPackages;
- 
         if (!string.IsNullOrEmpty(filePath))
         {
             if (!File.Exists(filePath))
@@ -469,12 +456,10 @@ public class GistGetService(
         }
         else if (!string.IsNullOrEmpty(url))
         {
-            // URL 指定時: HTTP でダウンロード（認証不要）
             gistPackages = await gitHubService.GetPackagesFromUrlAsync(url);
         }
         else
         {
-            // URL 未指定時: 認証ユーザーの Gist を使用
             if (!credentialService.TryGetCredential(out var credential))
             {
                 await AuthLoginAsync();
@@ -483,119 +468,120 @@ public class GistGetService(
                     throw new InvalidOperationException("Failed to retrieve credentials after login.");
                 }
             }
-            gistPackages = await gitHubService.GetPackagesAsync(credential.Token, Constants.DefaultGistFileName, Constants.DefaultGistDescription);
+
+            gistPackages = await gitHubService.GetPackagesAsync(
+                credential.Token,
+                Constants.DefaultGistFileName,
+                Constants.DefaultGistDescription);
         }
 
-        // ステップ3: ローカルのインストール済みパッケージを取得
         var localPackages = winGetService.GetAllInstalledPackages();
         var localPackageDict = localPackages.ToDictionary(
-            p => p.Id.AsPrimitive(), 
-            p => p, 
+            p => p.Id.AsPrimitive(),
+            p => p,
             StringComparer.OrdinalIgnoreCase);
 
-        // ステップ4: Phase 1 - アンインストール（uninstall: trueのパッケージ）
         foreach (var gistPkg in gistPackages.Where(p => p.Uninstall))
         {
-            if (localPackageDict.ContainsKey(gistPkg.Id))
+            if (!localPackageDict.ContainsKey(gistPkg.Id))
             {
-                try
+                continue;
+            }
+
+            try
+            {
+                consoleService.WriteInfo($"[sync] Uninstalling {gistPkg.Id}...");
+                var uninstallArgs = new[] { "uninstall", "--id", gistPkg.Id };
+                var exitCode = await passthroughRunner.RunAsync(uninstallArgs);
+                if (exitCode == 0)
                 {
-                    consoleService.WriteInfo($"[sync] Uninstalling {gistPkg.Id}...");
-                    var uninstallArgs = new[] { "uninstall", "--id", gistPkg.Id };
-                    var exitCode = await passthroughRunner.RunAsync(uninstallArgs);
-                    if (exitCode == 0)
-                    {
-                        result.Uninstalled.Add(gistPkg);
-                        // pinも削除
-                        consoleService.WriteInfo($"[sync] Removing pin for {gistPkg.Id}...");
-                        await passthroughRunner.RunAsync(new[] { "pin", "remove", "--id", gistPkg.Id });
-                    }
-                    else
-                    {
-                        result.Failed.Add(gistPkg);
-                        result.Errors.Add($"Failed to uninstall {gistPkg.Id}: exit code {exitCode}");
-                    }
+                    result.Uninstalled.Add(gistPkg);
+                    consoleService.WriteInfo($"[sync] Removing pin for {gistPkg.Id}...");
+                    await passthroughRunner.RunAsync(new[] { "pin", "remove", "--id", gistPkg.Id });
                 }
-                catch (Exception ex)
+                else
                 {
                     result.Failed.Add(gistPkg);
-                    result.Errors.Add($"Failed to uninstall {gistPkg.Id}: {ex.Message}");
+                    result.Errors.Add($"Failed to uninstall {gistPkg.Id}: exit code {exitCode}");
                 }
+            }
+            catch (Exception ex)
+            {
+                result.Failed.Add(gistPkg);
+                result.Errors.Add($"Failed to uninstall {gistPkg.Id}: {ex.Message}");
             }
         }
 
-        // ステップ5: Phase 2 - インストール（Gistにあり、ローカルにないパッケージ）
+        foreach (var gistPkg in gistPackages.Where(p => !p.Uninstall))
+        {
+            if (localPackageDict.ContainsKey(gistPkg.Id))
+            {
+                continue;
+            }
+
+            try
+            {
+                var installArgs = argumentBuilder.BuildInstallArgs(gistPkg);
+
+                consoleService.WriteInfo($"[sync] Installing {gistPkg.Id}...");
+                var exitCode = await passthroughRunner.RunAsync(installArgs.ToArray());
+                if (exitCode == 0)
+                {
+                    result.Installed.Add(gistPkg);
+
+                    if (!string.IsNullOrEmpty(gistPkg.Pin))
+                    {
+                        var pinArgs = argumentBuilder.BuildPinAddArgs(gistPkg.Id, gistPkg.Pin, gistPkg.PinType);
+                        consoleService.WriteInfo($"[sync] Pinning {gistPkg.Id} to {gistPkg.Pin}...");
+                        await passthroughRunner.RunAsync(pinArgs);
+                    }
+                }
+                else
+                {
+                    result.Failed.Add(gistPkg);
+                    result.Errors.Add($"Failed to install {gistPkg.Id}: exit code {exitCode}");
+                }
+            }
+            catch (Exception ex)
+            {
+                result.Failed.Add(gistPkg);
+                result.Errors.Add($"Failed to install {gistPkg.Id}: {ex.Message}");
+            }
+        }
+
         foreach (var gistPkg in gistPackages.Where(p => !p.Uninstall))
         {
             if (!localPackageDict.ContainsKey(gistPkg.Id))
             {
-                try
-                {
-                    var installArgs = argumentBuilder.BuildInstallArgs(gistPkg);
+                continue;
+            }
 
-                    consoleService.WriteInfo($"[sync] Installing {gistPkg.Id}...");
-                    var exitCode = await passthroughRunner.RunAsync(installArgs.ToArray());
+            try
+            {
+                if (!string.IsNullOrEmpty(gistPkg.Pin))
+                {
+                    var pinArgs = argumentBuilder.BuildPinAddArgs(gistPkg.Id, gistPkg.Pin, gistPkg.PinType, true);
+                    consoleService.WriteInfo($"[sync] Pinning {gistPkg.Id} to {gistPkg.Pin}...");
+                    var exitCode = await passthroughRunner.RunAsync(pinArgs);
                     if (exitCode == 0)
                     {
-                        result.Installed.Add(gistPkg);
-                        
-                        // Pinがある場合はpin addを実行
-                        if (!string.IsNullOrEmpty(gistPkg.Pin))
-                        {
-                            var pinArgs = argumentBuilder.BuildPinAddArgs(gistPkg.Id, gistPkg.Pin, gistPkg.PinType);
-                            consoleService.WriteInfo($"[sync] Pinning {gistPkg.Id} to {gistPkg.Pin}...");
-                            await passthroughRunner.RunAsync(pinArgs);
-                        }
-                    }
-                    else
-                    {
-                        result.Failed.Add(gistPkg);
-                        result.Errors.Add($"Failed to install {gistPkg.Id}: exit code {exitCode}");
+                        result.PinUpdated.Add(gistPkg);
                     }
                 }
-                catch (Exception ex)
+                else
                 {
-                    result.Failed.Add(gistPkg);
-                    result.Errors.Add($"Failed to install {gistPkg.Id}: {ex.Message}");
+                    var pinRemoveArgs = new[] { "pin", "remove", "--id", gistPkg.Id };
+                    consoleService.WriteInfo($"[sync] Removing pin for {gistPkg.Id}...");
+                    var exitCode = await passthroughRunner.RunAsync(pinRemoveArgs);
+                    if (exitCode == 0)
+                    {
+                        result.PinRemoved.Add(gistPkg);
+                    }
                 }
             }
-        }
-
-        // ステップ6: Phase 3 - Pin同期（既にインストール済みのパッケージのpin設定を同期）
-        foreach (var gistPkg in gistPackages.Where(p => !p.Uninstall))
-        {
-            if (localPackageDict.ContainsKey(gistPkg.Id))
+            catch (Exception ex)
             {
-                try
-                {
-                    if (!string.IsNullOrEmpty(gistPkg.Pin))
-                    {
-                        // GistにPinがある場合はローカルにPin追加/更新
-                        var pinArgs = argumentBuilder.BuildPinAddArgs(gistPkg.Id, gistPkg.Pin, gistPkg.PinType, true);
-                        consoleService.WriteInfo($"[sync] Pinning {gistPkg.Id} to {gistPkg.Pin}...");
-                        var exitCode = await passthroughRunner.RunAsync(pinArgs);
-                        if (exitCode == 0)
-                        {
-                            result.PinUpdated.Add(gistPkg);
-                        }
-                    }
-                    else
-                    {
-                        // GistにPinがない場合はローカルのPinを削除（存在する場合）
-                        // pin removeはエラーを無視（元々pinがない場合もあるため）
-                        var pinRemoveArgs = new[] { "pin", "remove", "--id", gistPkg.Id };
-                        consoleService.WriteInfo($"[sync] Removing pin for {gistPkg.Id}...");
-                        var exitCode = await passthroughRunner.RunAsync(pinRemoveArgs);
-                        if (exitCode == 0)
-                        {
-                            result.PinRemoved.Add(gistPkg);
-                        }
-                    }
-                }
-                catch (Exception ex)
-                {
-                    result.Errors.Add($"Failed to sync pin for {gistPkg.Id}: {ex.Message}");
-                }
+                result.Errors.Add($"Failed to sync pin for {gistPkg.Id}: {ex.Message}");
             }
         }
 
@@ -603,11 +589,8 @@ public class GistGetService(
     }
 
     /// <summary>
-    /// 指定されたコマンドをWinGetにそのままパススルーで実行します。
+    /// Runs a WinGet command without syncing.
     /// </summary>
-    /// <param name="command">WinGetコマンド（例: list, search, show）</param>
-    /// <param name="args">コマンドに渡す引数</param>
-    /// <returns>WinGetプロセスの終了コード</returns>
     public Task<int> RunPassthroughAsync(string command, string[] args)
     {
         var fullArgs = new List<string> { command };
@@ -616,34 +599,26 @@ public class GistGetService(
     }
 
     /// <summary>
-    /// ローカルにインストールされているパッケージをYAML形式でエクスポートします。
-    /// COMから取得可能な情報（ID）のみを出力します。
+    /// Exports installed packages to YAML.
     /// </summary>
-    /// <param name="outputPath">出力先ファイルパス（nullの場合は標準出力に出力）</param>
-    /// <returns>エクスポートされたYAML文字列</returns>
     public async Task<string> ExportAsync(string? outputPath = null)
     {
-        // ローカルのインストール済みパッケージを取得
         var installedPackages = winGetService.GetAllInstalledPackages();
-        
-        // GistGetPackage形式に変換（COMから取得可能な情報のみ）
+
         var packages = installedPackages.Select(p => new GistGetPackage
         {
-            Id = p.Id.AsPrimitive()
+            Id = p.Id.AsPrimitive(),
         }).ToList();
 
-        // YAMLにシリアライズ
         var yaml = GistGetPackageSerializer.Serialize(packages);
 
         if (!string.IsNullOrEmpty(outputPath))
         {
-            // ファイルに出力
             await File.WriteAllTextAsync(outputPath, yaml);
             consoleService.WriteInfo($"Exported {packages.Count} packages to {outputPath}");
         }
         else
         {
-            // 標準出力に出力
             Console.WriteLine(yaml);
         }
 
@@ -651,12 +626,10 @@ public class GistGetService(
     }
 
     /// <summary>
-    /// YAMLファイルからパッケージ情報を読み込み、Gistに保存します。
+    /// Imports package definitions from a YAML file.
     /// </summary>
-    /// <param name="filePath">読み込むYAMLファイルのパス</param>
     public async Task ImportAsync(string filePath)
     {
-        // 認証確認
         if (!credentialService.TryGetCredential(out var credential))
         {
             await AuthLoginAsync();
@@ -666,7 +639,6 @@ public class GistGetService(
             }
         }
 
-        // ファイルを読み込み
         if (!File.Exists(filePath))
         {
             throw new FileNotFoundException($"File not found: {filePath}");
@@ -675,8 +647,13 @@ public class GistGetService(
         var yaml = await File.ReadAllTextAsync(filePath);
         var packages = GistGetPackageSerializer.Deserialize(yaml);
 
-        // Gistに保存
-        await gitHubService.SavePackagesAsync(credential.Token, "", Constants.DefaultGistFileName, Constants.DefaultGistDescription, packages);
+        await gitHubService.SavePackagesAsync(
+            credential.Token,
+            "",
+            Constants.DefaultGistFileName,
+            Constants.DefaultGistDescription,
+            packages);
+
         consoleService.WriteInfo($"Imported {packages.Count} packages to Gist");
     }
 }

--- a/src/GistGet/GistGet/IConsoleService.cs
+++ b/src/GistGet/GistGet/IConsoleService.cs
@@ -1,33 +1,29 @@
-﻿namespace GistGet;
+﻿// Abstraction for writing user-facing output.
+
+namespace GistGet;
 
 /// <summary>
-/// コンソール入出力を抽象化するサービスインターフェース。
-/// ユーザーへのメッセージ表示やクリップボード操作を提供します。
+/// Defines console and clipboard operations used by the application.
 /// </summary>
 public interface IConsoleService
 {
     /// <summary>
-    /// 情報メッセージをコンソールに出力します。
+    /// Writes an informational message.
     /// </summary>
-    /// <param name="message">出力するメッセージ</param>
     void WriteInfo(string message);
 
     /// <summary>
-    /// 警告メッセージをコンソールに出力します。
+    /// Writes a warning message.
     /// </summary>
-    /// <param name="message">出力する警告メッセージ</param>
     void WriteWarning(string message);
 
     /// <summary>
-    /// コンソールから1行読み取ります。
+    /// Reads a single line of input.
     /// </summary>
-    /// <returns>読み取った文字列。入力がない場合はnull。</returns>
     string? ReadLine();
 
     /// <summary>
-    /// テキストをクリップボードに設定します。
-    /// Device Flow認証時のユーザーコードコピーなどに使用されます。
+    /// Copies text to the clipboard.
     /// </summary>
-    /// <param name="text">クリップボードに設定するテキスト</param>
     void SetClipboard(string text);
 }

--- a/src/GistGet/GistGet/ICredentialService.cs
+++ b/src/GistGet/GistGet/ICredentialService.cs
@@ -1,31 +1,26 @@
-﻿namespace GistGet;
+﻿// Abstraction for storing and retrieving credentials.
+
+namespace GistGet;
 
 using System.Diagnostics.CodeAnalysis;
 
 /// <summary>
-/// 認証資格情報の永続化を担当するサービスインターフェース。
-/// Windows資格情報マネージャーを使用してGitHubトークンを安全に保存・取得します。
+/// Defines operations for persisting and accessing authentication credentials.
 /// </summary>
 public interface ICredentialService
 {
     /// <summary>
-    /// 保存されている資格情報の取得を試みます。
+    /// Attempts to read the stored credential.
     /// </summary>
-    /// <param name="credential">取得した資格情報。取得できない場合はnull。</param>
-    /// <returns>資格情報が存在する場合はtrue、存在しない場合はfalse。</returns>
     bool TryGetCredential([NotNullWhen(true)] out Credential credential);
 
     /// <summary>
-    /// 資格情報をWindows資格情報マネージャーに保存します。
+    /// Persists a credential for later use.
     /// </summary>
-    /// <param name="credential">保存する資格情報（ユーザー名とトークン）</param>
-    /// <returns>保存が成功した場合はtrue。</returns>
     bool SaveCredential(Credential credential);
 
     /// <summary>
-    /// 保存されている資格情報を削除します。
-    /// ログアウト時に呼び出されます。
+    /// Deletes any stored credential.
     /// </summary>
-    /// <returns>削除が成功した場合はtrue。</returns>
     bool DeleteCredential();
 }

--- a/src/GistGet/GistGet/IGistGetService.cs
+++ b/src/GistGet/GistGet/IGistGetService.cs
@@ -1,97 +1,69 @@
-﻿namespace GistGet;
+﻿// Public contract for GistGet application workflows.
+
+namespace GistGet;
 
 /// <summary>
-/// GistGetの中核サービスインターフェース。
-/// GitHub Gistとの同期、WinGetコマンドの実行、認証管理を統合的に提供します。
-/// すべてのパッケージ操作はGistの<c>GistGet.yaml</c>と同期されます。
+/// Defines the main application operations exposed to the CLI layer.
 /// </summary>
 public interface IGistGetService
 {
     /// <summary>
-    /// GitHubへDevice Flowでログインし、資格情報を保存します。
-    /// ブラウザでの認証が必要です。
+    /// Authenticates via GitHub device flow and stores the credential.
     /// </summary>
     Task AuthLoginAsync();
 
     /// <summary>
-    /// GitHubからログアウトし、保存されている資格情報を削除します。
+    /// Logs out and removes any stored credential.
     /// </summary>
     void AuthLogout();
 
     /// <summary>
-    /// 現在の認証状態を表示します。
-    /// ログイン中の場合はユーザー名、トークン情報、スコープを表示します。
+    /// Displays the current authentication status.
     /// </summary>
     Task AuthStatusAsync();
 
     /// <summary>
-    /// パッケージをインストールし、Gistの<c>GistGet.yaml</c>に保存します。
-    /// 既存のPinがある場合はそのバージョンでインストールし、Pinを設定します。
+    /// Installs a package and persists it to the manifest.
     /// </summary>
-    /// <param name="options">インストールオプション（ID、バージョン、各種フラグ）</param>
-    /// <returns>wingetプロセスの終了コード（成功時は0）</returns>
     Task<int> InstallAndSaveAsync(InstallOptions options);
 
     /// <summary>
-    /// パッケージをアンインストールし、Gistの<c>GistGet.yaml</c>を更新します。
-    /// エントリに<c>uninstall: true</c>が設定され、他デバイスでのsync時にアンインストールされます。
+    /// Uninstalls a package and updates the manifest.
     /// </summary>
-    /// <param name="options">アンインストールオプション（ID、スコープ、各種フラグ）</param>
-    /// <returns>wingetプロセスの終了コード（成功時は0）</returns>
     Task<int> UninstallAndSaveAsync(UninstallOptions options);
 
     /// <summary>
-    /// パッケージをアップグレードし、Gistの<c>GistGet.yaml</c>を更新します。
-    /// Pinがある場合は新しいバージョンに更新されます。
+    /// Upgrades a package and updates the manifest.
     /// </summary>
-    /// <param name="options">アップグレードオプション（ID、バージョン、各種フラグ）</param>
-    /// <returns>wingetプロセスの終了コード（成功時は0）</returns>
     Task<int> UpgradeAndSaveAsync(UpgradeOptions options);
 
     /// <summary>
-    /// パッケージをピン留めし、Gistの<c>GistGet.yaml</c>に保存します。
-    /// Pinにより<c>upgrade --all</c>から除外されます。
+    /// Adds a pin and persists it to the manifest.
     /// </summary>
-    /// <param name="packageId">PinするパッケージのID</param>
-    /// <param name="version">Pinするバージョン（ワイルドカード使用可、例: "1.7.*"）</param>
-    /// <param name="pinType">Pinの種類（blocking, gating）。省略時は既存値を維持、なければ pinning</param>
-    /// <param name="force">既存のPinを上書きする場合はtrue</param>
     Task PinAddAndSaveAsync(string packageId, string version, string? pinType = null, bool force = false);
 
     /// <summary>
-    /// パッケージのピン留めを解除し、Gistの<c>GistGet.yaml</c>から<c>pin</c>を削除します。
+    /// Removes a pin and updates the manifest.
     /// </summary>
-    /// <param name="packageId">Pin解除するパッケージのID</param>
     Task PinRemoveAndSaveAsync(string packageId);
 
     /// <summary>
-    /// GistGet.yamlとローカル状態を同期します。
-    /// 差分を検出し、インストール/アンインストール/pin設定を実行します。
+    /// Synchronizes the manifest with local state.
     /// </summary>
-    /// <param name="url">同期元の YAML URL（省略時は認証ユーザーの Gist）</param>
-    /// <param name="filePath">同期元のローカル YAML ファイルパス（指定時はこれを優先）</param>
-    /// <returns>同期結果（インストール/アンインストール/失敗したパッケージ一覧）</returns>
     Task<SyncResult> SyncAsync(string? url = null, string? filePath = null);
 
     /// <summary>
-    /// 指定されたコマンドをWinGetにそのままパススルーで実行します。
-    /// list、search、showなどGist同期が不要なコマンドに使用されます。
+    /// Runs a WinGet command without syncing.
     /// </summary>
-    /// <param name="command">WinGetコマンド（例: list, search, show）</param>
-    /// <param name="args">コマンドに渡す引数</param>
-    /// <returns>WinGetプロセスの終了コード</returns>
     Task<int> RunPassthroughAsync(string command, string[] args);
 
     /// <summary>
-    /// ローカルにインストールされているパッケージをYAML形式でエクスポートします。
+    /// Exports installed packages to YAML.
     /// </summary>
-    /// <param name="outputPath">出力先ファイルパス（nullの場合は標準出力に出力）</param>
-    /// <returns>エクスポートされたYAML文字列</returns>
     Task<string> ExportAsync(string? outputPath = null);
 
     /// <summary>
-    /// YAMLファイルからパッケージ情報を読み込み、Gistに保存します。
+    /// Imports package definitions from a YAML file.
     /// </summary>
-    /// <param name="filePath">読み込むYAMLファイルのパス</param>
     Task ImportAsync(string filePath);
 }

--- a/src/GistGet/GistGet/IGitHubService.cs
+++ b/src/GistGet/GistGet/IGitHubService.cs
@@ -1,84 +1,39 @@
-﻿namespace GistGet;
+﻿// Abstraction over GitHub API interactions used by GistGet.
+
+namespace GistGet;
 
 /// <summary>
-/// GitHub APIとの通信を担当するサービスインターフェース。
-/// Device Flow認証とGist操作を提供します。
+/// Defines GitHub operations for authentication, Gist access, and package persistence.
 /// </summary>
-/// <remarks>
-/// <para><b>Gist特定ルール:</b></para>
-/// <list type="bullet">
-///   <item>
-///     <term>gistUrl指定時</term>
-///     <description>URLからGist IDを抽出し、そのGistを直接取得します。</description>
-///   </item>
-///   <item>
-///     <term>gistUrl未指定時</term>
-///     <description>
-///       認証ユーザーの全Gistを検索し、以下のいずれかの条件に一致するGistを特定します:
-///       <list type="number">
-///         <item>指定されたファイル名（gistFileName）を含むGist</item>
-///         <item>指定された説明（gistDescription）と一致するGist</item>
-///       </list>
-///     </description>
-///   </item>
-///   <item>
-///     <term>複数Gist一致時</term>
-///     <description>
-///       条件に一致するGistが複数存在する場合、<see cref="InvalidOperationException"/>をスローし、
-///       明示的なgistURL指定を要求します。
-///     </description>
-///   </item>
-/// </list>
-/// </remarks>
 public interface IGitHubService
 {
     /// <summary>
-    /// GitHub Device Flowを使用してログインします。
-    /// ユーザーはブラウザでコードを入力して認証を完了します。
+    /// Performs GitHub device flow login.
     /// </summary>
-    /// <returns>認証成功時の資格情報（ユーザー名とアクセストークン）</returns>
     Task<Credential> LoginAsync();
 
     /// <summary>
-    /// 指定された URL から GistGet.yaml を取得します。
-    /// Gist の Raw URL やその他の HTTP/HTTPS URL を指定可能です。
+    /// Loads packages from a YAML URL.
     /// </summary>
-    /// <param name="url">YAML ファイルの URL</param>
-    /// <returns>パッケージ一覧</returns>
     Task<IReadOnlyList<GistGetPackage>> GetPackagesFromUrlAsync(string url);
 
     /// <summary>
-    /// 認証ユーザーの Gist からパッケージ一覧を取得します。
+    /// Loads packages from a user-owned Gist.
     /// </summary>
-    /// <param name="token">GitHub アクセストークン</param>
-    /// <param name="gistFileName">Gist内のファイル名（通常は "GistGet.yaml"）</param>
-    /// <param name="gistDescription">Gistの説明（検索・作成時に使用）</param>
-    /// <returns>パッケージ一覧</returns>
     Task<IReadOnlyList<GistGetPackage>> GetPackagesAsync(string token, string gistFileName, string gistDescription);
 
     /// <summary>
-    /// パッケージ一覧をGistに保存します。
-    /// Gistが存在しない場合は新規作成します。
+    /// Saves packages to a Gist, creating it when needed.
     /// </summary>
-    /// <param name="token">GitHub アクセストークン</param>
-    /// <param name="gistUrl">Gist URL（空文字列の場合は認証ユーザーのGistを検索または作成）</param>
-    /// <param name="gistFileName">Gist内のファイル名（通常は "GistGet.yaml"）</param>
-    /// <param name="gistDescription">Gistの説明</param>
-    /// <param name="packages">保存するパッケージ一覧</param>
     Task SavePackagesAsync(string token, string gistUrl, string gistFileName, string gistDescription, IReadOnlyList<GistGetPackage> packages);
 
     /// <summary>
-    /// GitHubトークンの状態を取得します。
-    /// ユーザー名とスコープ情報を返します。
+    /// Returns token owner and scope information.
     /// </summary>
-    /// <param name="token">確認するアクセストークン</param>
-    /// <returns>トークンのステータス（ユーザー名とスコープ）</returns>
     Task<TokenStatus> GetTokenStatusAsync(string token);
 }
 
 /// <summary>
-/// GitHubトークンのステータス情報。
+/// Token owner and granted scopes.
 /// </summary>
-/// <param name="Username">トークンに関連付けられたユーザー名</param>
-/// <param name="Scopes">トークンに付与されたスコープ一覧</param>
 public record TokenStatus(string Username, IReadOnlyList<string> Scopes);

--- a/src/GistGet/GistGet/IUserInterface.cs
+++ b/src/GistGet/GistGet/IUserInterface.cs
@@ -1,14 +1,14 @@
-﻿namespace GistGet;
+﻿// Abstraction for user interaction and messaging.
+
+namespace GistGet;
 
 /// <summary>
-/// ユーザーインターフェースの抽象化レイヤー。
-/// テスト時にモック可能な出力インターフェースを提供します。
+/// Defines the user interaction surface used by application workflows.
 /// </summary>
 public interface IUserInterface
 {
     /// <summary>
-    /// メッセージを出力して改行します。
+    /// Writes a message followed by a newline.
     /// </summary>
-    /// <param name="message">出力するメッセージ</param>
     void WriteLine(string message);
 }

--- a/src/GistGet/GistGet/IWinGetPassthroughRunner.cs
+++ b/src/GistGet/GistGet/IWinGetPassthroughRunner.cs
@@ -1,16 +1,14 @@
-﻿namespace GistGet;
+﻿// Abstraction for executing WinGet commands as a passthrough.
+
+namespace GistGet;
 
 /// <summary>
-/// WinGetコマンドをパススルーで実行するサービスインターフェース。
-/// winget.exeを直接呼び出し、結果をそのまま返します。
-/// list、search、showなどGist同期が不要なコマンドに使用されます。
+/// Defines a runner that forwards commands to WinGet and returns exit codes.
 /// </summary>
 public interface IWinGetPassthroughRunner
 {
     /// <summary>
-    /// 指定された引数でWinGetを実行します。
+    /// Runs WinGet with the provided command-line arguments.
     /// </summary>
-    /// <param name="args">WinGetに渡すコマンドライン引数</param>
-    /// <returns>WinGetプロセスの終了コード</returns>
     Task<int> RunAsync(string[] args);
 }

--- a/src/GistGet/GistGet/IWinGetService.cs
+++ b/src/GistGet/GistGet/IWinGetService.cs
@@ -1,21 +1,19 @@
-﻿namespace GistGet;
+﻿// Abstraction for reading WinGet package information.
+
+namespace GistGet;
 
 /// <summary>
-/// WinGet COM APIを使用したパッケージ情報取得サービスインターフェース。
-/// ローカルにインストールされているパッケージの情報を取得します。
+/// Defines operations for discovering and querying WinGet packages.
 /// </summary>
 public interface IWinGetService
 {
     /// <summary>
-    /// パッケージIDでインストール済みパッケージを検索します。
+    /// Finds an installed package by package ID.
     /// </summary>
-    /// <param name="id">検索するパッケージID</param>
-    /// <returns>該当するパッケージ情報。見つからない場合はnull。</returns>
     WinGetPackage? FindById(PackageId id);
 
     /// <summary>
-    /// ローカルにインストールされている全パッケージを取得します。
+    /// Returns all installed packages.
     /// </summary>
-    /// <returns>インストール済みパッケージの一覧</returns>
     IReadOnlyList<WinGetPackage> GetAllInstalledPackages();
 }

--- a/src/GistGet/GistGet/Infrastructure/Diagnostics/IProcessRunner.cs
+++ b/src/GistGet/GistGet/Infrastructure/Diagnostics/IProcessRunner.cs
@@ -1,8 +1,16 @@
+// Abstraction for running external processes.
+
 using System.Diagnostics;
 
 namespace GistGet.Infrastructure.Diagnostics;
 
+/// <summary>
+/// Defines an API for executing processes and returning their exit code.
+/// </summary>
 public interface IProcessRunner
 {
+    /// <summary>
+    /// Runs a process and returns its exit code.
+    /// </summary>
     Task<int> RunAsync(ProcessStartInfo startInfo);
 }

--- a/src/GistGet/GistGet/Infrastructure/Diagnostics/ProcessRunner.cs
+++ b/src/GistGet/GistGet/Infrastructure/Diagnostics/ProcessRunner.cs
@@ -1,9 +1,17 @@
+// Default implementation for running external processes.
+
 using System.Diagnostics;
 
 namespace GistGet.Infrastructure.Diagnostics;
 
+/// <summary>
+/// Runs a process and returns its exit code.
+/// </summary>
 public class ProcessRunner : IProcessRunner
 {
+    /// <summary>
+    /// Runs the specified process and returns its exit code.
+    /// </summary>
     public async Task<int> RunAsync(ProcessStartInfo startInfo)
     {
         using var process = new Process { StartInfo = startInfo };

--- a/src/GistGet/GistGet/Infrastructure/GitHubClientFactory.cs
+++ b/src/GistGet/GistGet/Infrastructure/GitHubClientFactory.cs
@@ -1,9 +1,17 @@
+// Factory for creating configured GitHub client wrappers.
+
 using Octokit;
 
 namespace GistGet.Infrastructure;
 
+/// <summary>
+/// Creates GitHub client wrappers configured for optional authentication.
+/// </summary>
 public class GitHubClientFactory : IGitHubClientFactory
 {
+    /// <summary>
+    /// Creates a client wrapper configured with an optional token.
+    /// </summary>
     public IGitHubClientWrapper Create(string? token)
     {
         var client = new GitHubClient(new ProductHeaderValue(Constants.ProductHeader));

--- a/src/GistGet/GistGet/Infrastructure/IGitHubClientFactory.cs
+++ b/src/GistGet/GistGet/Infrastructure/IGitHubClientFactory.cs
@@ -1,20 +1,62 @@
+// Abstraction for creating GitHub API clients.
+
 using Octokit;
 
 namespace GistGet.Infrastructure;
 
+/// <summary>
+/// Defines a factory for producing configured GitHub client instances.
+/// </summary>
 public interface IGitHubClientFactory
 {
+    /// <summary>
+    /// Creates a client wrapper configured with an optional token.
+    /// </summary>
     IGitHubClientWrapper Create(string? token);
 }
 
+/// <summary>
+/// Minimal GitHub client surface used by the application.
+/// </summary>
 public interface IGitHubClientWrapper
 {
+    /// <summary>
+    /// Starts a device flow authorization.
+    /// </summary>
     Task<OauthDeviceFlowResponse> InitiateDeviceFlowAsync(OauthDeviceFlowRequest request);
+
+    /// <summary>
+    /// Exchanges a device flow response for an access token.
+    /// </summary>
     Task<OauthToken> CreateAccessTokenForDeviceFlowAsync(string clientId, OauthDeviceFlowResponse response);
+
+    /// <summary>
+    /// Returns the current authenticated user.
+    /// </summary>
     Task<User> GetCurrentUserAsync();
+
+    /// <summary>
+    /// Returns API response metadata from the last call.
+    /// </summary>
     ApiInfo? GetLastApiInfo();
+
+    /// <summary>
+    /// Returns all gists for the current user.
+    /// </summary>
     Task<IReadOnlyList<Gist>> GetAllGistsAsync();
+
+    /// <summary>
+    /// Loads a gist by ID.
+    /// </summary>
     Task<Gist> GetGistAsync(string id);
+
+    /// <summary>
+    /// Updates an existing gist.
+    /// </summary>
     Task<Gist> EditGistAsync(string id, GistUpdate update);
+
+    /// <summary>
+    /// Creates a new gist.
+    /// </summary>
     Task<Gist> CreateGistAsync(NewGist gist);
 }

--- a/src/GistGet/GistGet/Infrastructure/IWinGetArgumentBuilder.cs
+++ b/src/GistGet/GistGet/Infrastructure/IWinGetArgumentBuilder.cs
@@ -1,34 +1,36 @@
+// Abstraction for building WinGet command-line arguments.
+
 using System.Collections.Generic;
 
 namespace GistGet.Infrastructure;
 
 /// <summary>
-/// WinGet コマンドの引数を構築するビルダーインターフェース。
+/// Defines argument construction for WinGet operations invoked by the app.
 /// </summary>
 public interface IWinGetArgumentBuilder
 {
     /// <summary>
-    /// install コマンドの引数を構築します。
+    /// Builds arguments for an install operation.
     /// </summary>
     string[] BuildInstallArgs(InstallOptions options);
 
     /// <summary>
-    /// GistGetPackage から install コマンドの引数を構築します。
+    /// Builds install arguments from a package entry.
     /// </summary>
     string[] BuildInstallArgs(GistGetPackage package);
 
     /// <summary>
-    /// upgrade コマンドの引数を構築します。
+    /// Builds arguments for an upgrade operation.
     /// </summary>
     string[] BuildUpgradeArgs(UpgradeOptions options);
 
     /// <summary>
-    /// uninstall コマンドの引数を構築します。
+    /// Builds arguments for an uninstall operation.
     /// </summary>
     string[] BuildUninstallArgs(UninstallOptions options);
 
     /// <summary>
-    /// pin add コマンドの引数を構築します。
+    /// Builds arguments for a pin add operation.
     /// </summary>
     string[] BuildPinAddArgs(string id, string version, string? pinType = null, bool force = false);
 }

--- a/src/GistGet/GistGet/Infrastructure/WinGetArgumentBuilder.cs
+++ b/src/GistGet/GistGet/Infrastructure/WinGetArgumentBuilder.cs
@@ -1,9 +1,17 @@
+// Builds WinGet command-line arguments from options and package entries.
+
 using System.Collections.Generic;
 
 namespace GistGet.Infrastructure;
 
+/// <summary>
+/// Constructs argument arrays for invoking WinGet.
+/// </summary>
 public class WinGetArgumentBuilder : IWinGetArgumentBuilder
 {
+    /// <summary>
+    /// Builds arguments for an install command.
+    /// </summary>
     public string[] BuildInstallArgs(InstallOptions options)
     {
         var args = new List<string> { "install", "--id", options.Id };
@@ -44,8 +52,6 @@ public class WinGetArgumentBuilder : IWinGetArgumentBuilder
         var args = new List<string> { "upgrade", "--id", options.Id };
 
         if (!string.IsNullOrEmpty(options.Version)) { args.Add("--version"); args.Add(options.Version); }
-
-        // Upgrade shares most options with Install
         args.AddRange(BuildCommonInstallOptions(
             options.Scope, options.Architecture, options.Location,
             options.Interactive, options.Silent, options.Log,

--- a/src/GistGet/GistGet/Infrastructure/WinGetPassthroughRunner.cs
+++ b/src/GistGet/GistGet/Infrastructure/WinGetPassthroughRunner.cs
@@ -1,7 +1,12 @@
-﻿using System.Diagnostics;
+﻿// Runs WinGet as an external process and returns its exit code.
+
+using System.Diagnostics;
 
 namespace GistGet.Infrastructure.Diagnostics;
 
+/// <summary>
+/// Executes WinGet as a child process.
+/// </summary>
 public class WinGetPassthroughRunner : IWinGetPassthroughRunner
 {
     private readonly IProcessRunner _processRunner;
@@ -11,6 +16,9 @@ public class WinGetPassthroughRunner : IWinGetPassthroughRunner
         _processRunner = processRunner;
     }
 
+    /// <summary>
+    /// Runs WinGet with the given arguments.
+    /// </summary>
     public async Task<int> RunAsync(string[] args)
     {
         var startInfo = new ProcessStartInfo
@@ -22,7 +30,6 @@ public class WinGetPassthroughRunner : IWinGetPassthroughRunner
             RedirectStandardError = false
         };
 
-        // ArgumentListを使用してスペースを含む引数を正しくエスケープ
         foreach (var arg in args)
         {
             startInfo.ArgumentList.Add(arg);
@@ -33,7 +40,6 @@ public class WinGetPassthroughRunner : IWinGetPassthroughRunner
 
     private string ResolveWinGetPath()
     {
-        // 1. PATH 上の winget を探索
         var pathEnv = Environment.GetEnvironmentVariable("PATH");
         if (pathEnv != null)
         {
@@ -48,9 +54,7 @@ public class WinGetPassthroughRunner : IWinGetPassthroughRunner
             }
         }
 
-        // 2. フォールバック: LocalAppData
         var localAppData = Environment.GetEnvironmentVariable("LOCALAPPDATA");
         return Path.Combine(localAppData!, "Microsoft", "WindowsApps", "winget.exe");
     }
-
 }

--- a/src/GistGet/GistGet/InstallOptions.cs
+++ b/src/GistGet/GistGet/InstallOptions.cs
@@ -1,62 +1,28 @@
+// Command options for installing a package via GistGet.
+
 namespace GistGet;
 
 /// <summary>
-/// install コマンドの CLI 引数を表す record。
-/// 永続化用の GistGetPackage とは分離し、Presentation層からApplication層への受け渡しに使用。
+/// Represents CLI options for the install workflow.
 /// </summary>
 public record InstallOptions
 {
-    /// <summary>パッケージ ID（必須）</summary>
     public required string Id { get; init; }
-
-    /// <summary>インストールするバージョン</summary>
     public string? Version { get; init; }
-
-    /// <summary>インストールスコープ (user | machine)</summary>
     public string? Scope { get; init; }
-
-    /// <summary>アーキテクチャ (x86 | x64 | arm | arm64)</summary>
     public string? Architecture { get; init; }
-
-    /// <summary>インストール先パス</summary>
     public string? Location { get; init; }
-
-    /// <summary>ロケール (BCP47形式)</summary>
     public string? Locale { get; init; }
-
-    /// <summary>ログファイルパス</summary>
     public string? Log { get; init; }
-
-    /// <summary>カスタム HTTP ヘッダー</summary>
     public string? Header { get; init; }
-
-    /// <summary>追加のインストーラー引数</summary>
     public string? Custom { get; init; }
-
-    /// <summary>インストーラー引数の上書き</summary>
     public string? Override { get; init; }
-
-    /// <summary>インストーラータイプ</summary>
     public string? InstallerType { get; init; }
-
-    /// <summary>対話型インストール</summary>
     public bool Interactive { get; init; }
-
-    /// <summary>サイレントインストール</summary>
     public bool Silent { get; init; }
-
-    /// <summary>強制実行</summary>
     public bool Force { get; init; }
-
-    /// <summary>パッケージ契約に同意</summary>
     public bool AcceptPackageAgreements { get; init; }
-
-    /// <summary>ソース契約に同意</summary>
     public bool AcceptSourceAgreements { get; init; }
-
-    /// <summary>ハッシュ不一致を無視</summary>
     public bool AllowHashMismatch { get; init; }
-
-    /// <summary>依存関係をスキップ</summary>
     public bool SkipDependencies { get; init; }
 }

--- a/src/GistGet/GistGet/PackageId.cs
+++ b/src/GistGet/GistGet/PackageId.cs
@@ -1,6 +1,11 @@
-﻿using UnitGenerator;
+﻿// Strongly-typed package identifier value object.
+
+using UnitGenerator;
 
 namespace GistGet;
 
+/// <summary>
+/// Represents a WinGet package identifier as a strongly typed value.
+/// </summary>
 [UnitOf(typeof(string))]
 public partial struct PackageId;

--- a/src/GistGet/GistGet/Presentation/CommandBuilder.cs
+++ b/src/GistGet/GistGet/Presentation/CommandBuilder.cs
@@ -1,11 +1,19 @@
+// System.CommandLine command definitions for the GistGet CLI.
+
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using Spectre.Console;
 
 namespace GistGet.Presentation;
 
+/// <summary>
+/// Builds the root command and subcommands for the CLI.
+/// </summary>
 public class CommandBuilder(IGistGetService gistGetService)
 {
+    /// <summary>
+    /// Builds the root command tree.
+    /// </summary>
     public RootCommand Build()
     {
         var rootCommand = new RootCommand("GistGet - Windows Package Manager Cloud Sync Tool");
@@ -40,8 +48,6 @@ public class CommandBuilder(IGistGetService gistGetService)
         command.SetHandler(async (url, filePath) =>
         {
             var result = await gistGetService.SyncAsync(url, filePath);
-
-            // 結果を表示
             if (result.Installed.Count > 0)
             {
                 AnsiConsole.MarkupLine($"[green]Installed {result.Installed.Count} package(s):[/]");
@@ -325,16 +331,12 @@ public class CommandBuilder(IGistGetService gistGetService)
         command.Add(acceptPackageAgreementsOption);
         command.Add(acceptSourceAgreementsOption);
         command.Add(ignoreSecurityHashOption);
-
-        // Allow unmatched tokens to be collected for passthrough
         command.TreatUnmatchedTokensAsErrors = false;
 
         command.SetHandler(async context =>
         {
             var parseResult = context.ParseResult;
             var id = parseResult.GetValueForOption(idOption) ?? parseResult.GetValueForArgument(idArgument);
-
-            // If ID is specified, perform managed upgrade
             if (!string.IsNullOrWhiteSpace(id))
             {
                 var options = new UpgradeOptions
@@ -363,7 +365,6 @@ public class CommandBuilder(IGistGetService gistGetService)
             }
             else
             {
-                // ID未指定時はパススルー。UnmatchedTokensを使用して安定した引数取得
                 var argsToPass = parseResult.UnmatchedTokens.ToArray();
                 context.ExitCode = await gistGetService.RunPassthroughAsync("upgrade", argsToPass);
             }

--- a/src/GistGet/GistGet/Presentation/ConsoleService.cs
+++ b/src/GistGet/GistGet/Presentation/ConsoleService.cs
@@ -1,3 +1,5 @@
+// Console I/O implementation for the CLI layer.
+
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
@@ -5,6 +7,9 @@ using GistGet.Infrastructure.Diagnostics;
 
 namespace GistGet.Presentation;
 
+/// <summary>
+/// Writes messages to the console and provides clipboard support.
+/// </summary>
 public class ConsoleService : IConsoleService
 {
     private readonly IProcessRunner _processRunner;
@@ -14,16 +19,25 @@ public class ConsoleService : IConsoleService
         _processRunner = processRunner;
     }
 
+    /// <summary>
+    /// Writes an informational message.
+    /// </summary>
     public void WriteInfo(string message)
     {
         Console.WriteLine(message);
     }
 
+    /// <summary>
+    /// Writes a warning message.
+    /// </summary>
     public void WriteWarning(string message)
     {
         Console.WriteLine($"! {message}");
     }
 
+    /// <summary>
+    /// Reads a single line from standard input.
+    /// </summary>
     public string? ReadLine()
     {
         return Console.ReadLine();
@@ -41,7 +55,6 @@ public class ConsoleService : IConsoleService
     [SupportedOSPlatform("windows")]
     private void SetClipboardWindows(string text)
     {
-        // Use PowerShell to set clipboard on Windows
         var escaped = text.Replace("'", "''");
         var arguments = $"-Command \"Set-Clipboard -Value '{escaped}'\"";
         var startInfo = new ProcessStartInfo

--- a/src/GistGet/GistGet/SyncResult.cs
+++ b/src/GistGet/GistGet/SyncResult.cs
@@ -1,8 +1,9 @@
+// Result model for a sync operation between Gist and local packages.
+
 namespace GistGet;
 
 /// <summary>
-/// sync操作の結果を表すクラス。
-/// インストール、アンインストール、Pin更新、失敗の各パッケージを追跡します。
+/// Captures the outcome of a sync operation, including changes and errors.
 /// </summary>
 public class SyncResult
 {

--- a/src/GistGet/GistGet/UninstallOptions.cs
+++ b/src/GistGet/GistGet/UninstallOptions.cs
@@ -1,23 +1,15 @@
+// Command options for uninstalling a package via GistGet.
+
 namespace GistGet;
 
 /// <summary>
-/// uninstall コマンドの CLI 引数を表す record。
-/// 永続化用の GistGetPackage とは分離し、Presentation層からApplication層への受け渡しに使用。
+/// Represents CLI options for the uninstall workflow.
 /// </summary>
 public record UninstallOptions
 {
-    /// <summary>パッケージ ID（必須）</summary>
     public required string Id { get; init; }
-
-    /// <summary>インストールスコープ (user | machine)</summary>
     public string? Scope { get; init; }
-
-    /// <summary>対話型アンインストール</summary>
     public bool Interactive { get; init; }
-
-    /// <summary>サイレントアンインストール</summary>
     public bool Silent { get; init; }
-
-    /// <summary>強制実行</summary>
     public bool Force { get; init; }
 }

--- a/src/GistGet/GistGet/UpgradeOptions.cs
+++ b/src/GistGet/GistGet/UpgradeOptions.cs
@@ -1,62 +1,28 @@
+// Command options for upgrading packages via GistGet.
+
 namespace GistGet;
 
 /// <summary>
-/// upgrade コマンドの CLI 引数を表す record。
-/// 永続化用の GistGetPackage とは分離し、Presentation層からApplication層への受け渡しに使用。
+/// Represents CLI options for the upgrade workflow.
 /// </summary>
 public record UpgradeOptions
 {
-    /// <summary>パッケージ ID（必須）</summary>
     public required string Id { get; init; }
-
-    /// <summary>アップグレード先のバージョン</summary>
     public string? Version { get; init; }
-
-    /// <summary>インストールスコープ (user | machine)</summary>
     public string? Scope { get; init; }
-
-    /// <summary>アーキテクチャ (x86 | x64 | arm | arm64)</summary>
     public string? Architecture { get; init; }
-
-    /// <summary>インストール先パス</summary>
     public string? Location { get; init; }
-
-    /// <summary>ロケール (BCP47形式)</summary>
     public string? Locale { get; init; }
-
-    /// <summary>ログファイルパス</summary>
     public string? Log { get; init; }
-
-    /// <summary>追加のインストーラー引数</summary>
     public string? Custom { get; init; }
-
-    /// <summary>インストーラー引数の上書き</summary>
     public string? Override { get; init; }
-
-    /// <summary>インストーラータイプ</summary>
     public string? InstallerType { get; init; }
-
-    /// <summary>カスタム HTTP ヘッダー</summary>
     public string? Header { get; init; }
-
-    /// <summary>対話型アップグレード</summary>
     public bool Interactive { get; init; }
-
-    /// <summary>サイレントアップグレード</summary>
     public bool Silent { get; init; }
-
-    /// <summary>強制実行</summary>
     public bool Force { get; init; }
-
-    /// <summary>パッケージ契約に同意</summary>
     public bool AcceptPackageAgreements { get; init; }
-
-    /// <summary>ソース契約に同意</summary>
     public bool AcceptSourceAgreements { get; init; }
-
-    /// <summary>ハッシュ不一致を無視</summary>
     public bool AllowHashMismatch { get; init; }
-
-    /// <summary>依存関係をスキップ</summary>
     public bool SkipDependencies { get; init; }
 }

--- a/src/GistGet/GistGet/Version.cs
+++ b/src/GistGet/GistGet/Version.cs
@@ -1,6 +1,11 @@
-﻿using UnitGenerator;
+﻿// Strongly-typed version value used by GistGet models and workflows.
+
+using UnitGenerator;
 
 namespace GistGet;
 
+/// <summary>
+/// Represents a version string as a strongly typed value.
+/// </summary>
 [UnitOf(typeof(string))]
 public partial struct Version;

--- a/src/GistGet/GistGet/WinGetPackage.cs
+++ b/src/GistGet/GistGet/WinGetPackage.cs
@@ -1,5 +1,10 @@
-﻿namespace GistGet;
+﻿// Local WinGet package model used for listing and comparisons.
 
+namespace GistGet;
+
+/// <summary>
+/// Represents a package as reported by WinGet on the local machine.
+/// </summary>
 public record WinGetPackage(
     string Name,
     PackageId Id,

--- a/src/GistGet/Program.cs
+++ b/src/GistGet/Program.cs
@@ -1,4 +1,6 @@
-﻿using System.CommandLine;
+﻿// GistGet CLI entry point and dependency injection bootstrap.
+
+using System.CommandLine;
 using GistGet;
 using GistGet.Infrastructure;
 using GistGet.Infrastructure.Diagnostics;
@@ -7,16 +9,13 @@ using Microsoft.Extensions.DependencyInjection;
 
 ServiceCollection services = new();
 
-// GistGet
 services.AddSingleton<IGitHubClientFactory, GitHubClientFactory>();
 services.AddTransient<IGitHubService, GitHubService>();
 services.AddTransient<IGistGetService, GistGetService>();
 
-// Presentation
 services.AddTransient<CommandBuilder>();
 services.AddTransient<IConsoleService, ConsoleService>();
 
-// Infrastructure
 services.AddTransient<ICredentialService, CredentialService>();
 services.AddSingleton<IProcessRunner, ProcessRunner>();
 services.AddTransient<IWinGetPassthroughRunner, WinGetPassthroughRunner>();
@@ -28,3 +27,10 @@ await services
     .GetRequiredService<CommandBuilder>()
     .Build()
     .InvokeAsync(args);
+
+/// <summary>
+/// Entry point type for the top-level program.
+/// </summary>
+internal partial class Program
+{
+}

--- a/src/GistGet/Properties/IsExternalInit.cs
+++ b/src/GistGet/Properties/IsExternalInit.cs
@@ -1,7 +1,12 @@
-﻿#pragma warning disable IDE0130
+﻿// Polyfill type required for init-only setters on older target frameworks.
+
+#pragma warning disable IDE0130
 namespace GistGet.Properties
 #pragma warning restore IDE0130
 {
+    /// <summary>
+    /// Provides the IsExternalInit type required for init-only setters.
+    /// </summary>
     internal sealed class IsExternalInit
     { }
 }


### PR DESCRIPTION
## Summary\n- Remove existing comments and add concise English file headers and XML documentation across production code under src/GistGet/GistGet.\n- Keep test files unchanged so Arrange/Act/Assert separators remain.\n\n## Validation\n- dotnet build src/GistGet.slnx -c Debug\n- dotnet test src/GistGet.Test/GistGet.Test.csproj -c Debug\n\n## Notes\n- Program.cs uses top-level statements; XML docs are provided via internal partial Program.