### PR TITLE
syncのエラー出力でマークアップをエスケープ

### DIFF
--- a/src/GistGet.Test/Presentation/CommandBuilderTests.cs
+++ b/src/GistGet.Test/Presentation/CommandBuilderTests.cs
@@ -183,6 +183,36 @@ public class CommandBuilderTests : IDisposable
         }
 
         [Fact]
+        public async Task WithMarkupInErrors_PrintsRawMessage()
+        {
+            // -------------------------------------------------------------------
+            // Arrange
+            // -------------------------------------------------------------------
+            var target = CreateTarget();
+            var root = target.Build();
+            var result = new SyncResult
+            {
+                Errors = { "winget error: [not-a-tag]" }
+            };
+
+            GistGetServiceMock
+                .Setup(x => x.SyncAsync(null, null))
+                .ReturnsAsync(result);
+
+            // -------------------------------------------------------------------
+            // Act
+            // -------------------------------------------------------------------
+            var exitCode = await root.InvokeAsync("sync");
+            var output = TestConsole.Output;
+
+            // -------------------------------------------------------------------
+            // Assert
+            // -------------------------------------------------------------------
+            exitCode.ShouldBe(0);
+            output.ShouldContain("winget error: [not-a-tag]");
+        }
+
+        [Fact]
         public async Task AlreadyInSync_PrintsNoChangesMessage()
         {
             // -------------------------------------------------------------------

--- a/src/GistGet/Presentation/CommandBuilder.cs
+++ b/src/GistGet/Presentation/CommandBuilder.cs
@@ -58,7 +58,7 @@ public class CommandBuilder(IGistGetService gistGetService, IAnsiConsole console
                 console.MarkupLine($"[green]Installed {result.Installed.Count} package(s):[/]");
                 foreach (var pkg in result.Installed)
                 {
-                    console.MarkupLine($"  - {pkg.Id}");
+                    console.MarkupLine($"  - {EscapeMarkup(pkg.Id)}");
                 }
             }
 
@@ -67,7 +67,7 @@ public class CommandBuilder(IGistGetService gistGetService, IAnsiConsole console
                 console.MarkupLine($"[yellow]Uninstalled {result.Uninstalled.Count} package(s):[/]");
                 foreach (var pkg in result.Uninstalled)
                 {
-                    console.MarkupLine($"  - {pkg.Id}");
+                    console.MarkupLine($"  - {EscapeMarkup(pkg.Id)}");
                 }
             }
 
@@ -76,7 +76,7 @@ public class CommandBuilder(IGistGetService gistGetService, IAnsiConsole console
                 console.MarkupLine($"[blue]Updated pin for {result.PinUpdated.Count} package(s):[/]");
                 foreach (var pkg in result.PinUpdated)
                 {
-                    console.MarkupLine($"  - {pkg.Id}: {pkg.Pin}");
+                    console.MarkupLine($"  - {EscapeMarkup(pkg.Id)}: {EscapeMarkup(pkg.Pin)}");
                 }
             }
 
@@ -85,7 +85,7 @@ public class CommandBuilder(IGistGetService gistGetService, IAnsiConsole console
                 console.MarkupLine($"[blue]Removed pin for {result.PinRemoved.Count} package(s):[/]");
                 foreach (var pkg in result.PinRemoved)
                 {
-                    console.MarkupLine($"  - {pkg.Id}");
+                    console.MarkupLine($"  - {EscapeMarkup(pkg.Id)}");
                 }
             }
 
@@ -94,7 +94,7 @@ public class CommandBuilder(IGistGetService gistGetService, IAnsiConsole console
                 console.MarkupLine($"[red]Failed {result.Failed.Count} package(s):[/]");
                 foreach (var pkg in result.Failed)
                 {
-                    console.MarkupLine($"  - {pkg.Id}");
+                    console.MarkupLine($"  - {EscapeMarkup(pkg.Id)}");
                 }
             }
 
@@ -103,7 +103,7 @@ public class CommandBuilder(IGistGetService gistGetService, IAnsiConsole console
                 console.MarkupLine("[red]Errors:[/]");
                 foreach (var error in result.Errors)
                 {
-                    console.MarkupLine($"  - {error}");
+                    console.MarkupLine($"  - {EscapeMarkup(error)}");
                 }
             }
 
@@ -118,6 +118,11 @@ public class CommandBuilder(IGistGetService gistGetService, IAnsiConsole console
         }, urlOption, fileOption);
 
         return command;
+    }
+
+    private static string EscapeMarkup(string? value)
+    {
+        return Markup.Escape(value ?? string.Empty);
     }
 
     private Command BuildInitCommand()


### PR DESCRIPTION
## 変更内容
- sync結果のパッケージID/エラー文字列をMarkup.Escapeして出力
- マークアップ混入時の出力テストを追加

## 背景
- Spectre.ConsoleのMarkupLineが'['を含む文字列で例外になるため

## 動作確認
- `dotnet test src/GistGet.Test/GistGet.Test.csproj -c Debug --filter FullyQualifiedName~CommandBuilderTests+SyncCommand`