### PR TITLE
fix: インストール後の実バージョンをGistに保存

### DIFF
--- a/src/GistGet/GistGetService.cs
+++ b/src/GistGet/GistGetService.cs
@@ -170,12 +170,12 @@ public class GistGetService(
             .Where(p => !string.Equals(p.Id, options.Id, StringComparison.OrdinalIgnoreCase))
             .ToList();
 
-        var versionToSave = pinVersionToSet;
+        var installedVersion = localPackage.Version.ToString();
         var packageToSave = new GistGetPackage
         {
             Id = options.Id,
             Name = localPackage.Name,
-            Version = versionToSave,
+            Version = installedVersion,
             Pin = pinVersionToSet,
             PinType = pinTypeToSet,
             Silent = options.Silent,


### PR DESCRIPTION
## 変更内容\n- install後に取得した実インストール版をGistへ保存するように変更\n- InstallAndSaveAsyncのテストで実版保存を検証\n\n## 目的\n- 指定バージョン(例: 1.7.0)と実インストール版(例: 1.7)の差異をGistへ反映するため\n\n## 確認方法\n- 未実行（例: dotnet test src/GistGet.Test/GistGet.Test.csproj -c Debug）