### PR TITLE
docs: 1.0.5の変更履歴を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.5] - 2025-12-24
+
+### Fixed
+
+- `install`後にGistへ保存するバージョンを実際のインストール済みバージョンに修正
+- `sync`結果の出力でマークアップをエスケープし、記号を含むIDやエラーでも表示が崩れないよう修正
+
 ## [1.0.4] - 2025-12-21
 
 ### Added
@@ -19,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - YAML-based configuration management (`GistGet.yaml`)
 - Secure credential storage using Windows Credential Manager
 
-[Unreleased]: https://github.com/nuitsjp/GistGet/compare/v1.0.1...HEAD
+[Unreleased]: https://github.com/nuitsjp/GistGet/compare/v1.0.5...HEAD
+[1.0.5]: https://github.com/nuitsjp/GistGet/compare/v1.0.4...v1.0.5
+[1.0.4]: https://github.com/nuitsjp/GistGet/releases/tag/v1.0.4
 [1.0.1]: https://github.com/nuitsjp/GistGet/releases/tag/v1.0.1
 [1.0.0]: https://github.com/nuitsjp/GistGet/releases/tag/v1.0.0


### PR DESCRIPTION
## 変更内容
- 1.0.5の変更履歴を追加
- リンク定義を更新

## 目的
- v1.0.4以降のユーザー向け変更を明記

## 確認
- 未実施（ドキュメント変更のみ）