### PR TITLE
同期時の進捗表示を追加

### DIFF
--- a/src/GistGet/GistGetService.cs
+++ b/src/GistGet/GistGetService.cs
@@ -598,7 +598,11 @@ public class GistGetService(
 
         var gistPackages = await GistGetPackagesAsync(url, filePath);
 
-        var localPackages = winGetService.GetAllInstalledPackages();
+        IReadOnlyList<WinGetPackage> localPackages;
+        using (consoleService.WriteProgress(Messages.FetchingInstalledPackages))
+        {
+            localPackages = winGetService.GetAllInstalledPackages();
+        }
 
         var localPackageDict = localPackages.ToDictionary(
             p => p.Id.AsPrimitive(),
@@ -606,7 +610,11 @@ public class GistGetService(
             StringComparer.OrdinalIgnoreCase);
 
         // Get current pinned packages to avoid unnecessary pin operations
-        var pinnedPackages = winGetService.GetPinnedPackages();
+        IReadOnlyList<WinGetPin> pinnedPackages;
+        using (consoleService.WriteProgress(Messages.FetchingPinnedPackages))
+        {
+            pinnedPackages = winGetService.GetPinnedPackages();
+        }
         var pinnedPackageDict = pinnedPackages.ToDictionary(
             p => p.Id.AsPrimitive(),
             p => p,

--- a/src/GistGet/Resources/Messages.Designer.cs
+++ b/src/GistGet/Resources/Messages.Designer.cs
@@ -54,6 +54,12 @@ internal static class Messages
         ResourceManager.GetString("FetchingInstalledPackages", null) ?? string.Empty;
 
     /// <summary>
+    /// Looks up a localized string similar to: Fetching pinned packages...
+    /// </summary>
+    internal static string FetchingPinnedPackages =>
+        ResourceManager.GetString("FetchingPinnedPackages", null) ?? string.Empty;
+
+    /// <summary>
     /// Looks up a localized string similar to: Loading package information from file...
     /// </summary>
     internal static string LoadingFromFile =>

--- a/src/GistGet/Resources/Messages.ja.resx
+++ b/src/GistGet/Resources/Messages.ja.resx
@@ -53,6 +53,9 @@
   <data name="FetchingInstalledPackages" xml:space="preserve">
     <value>インストール済みパッケージを取得中...</value>
   </data>
+  <data name="FetchingPinnedPackages" xml:space="preserve">
+    <value>ピン留め済みパッケージを取得中...</value>
+  </data>
   <data name="LoadingFromFile" xml:space="preserve">
     <value>ファイルからパッケージ情報を読み込み中...</value>
   </data>

--- a/src/GistGet/Resources/Messages.resx
+++ b/src/GistGet/Resources/Messages.resx
@@ -53,6 +53,9 @@
   <data name="FetchingInstalledPackages" xml:space="preserve">
     <value>Fetching installed packages...</value>
   </data>
+  <data name="FetchingPinnedPackages" xml:space="preserve">
+    <value>Fetching pinned packages...</value>
+  </data>
   <data name="LoadingFromFile" xml:space="preserve">
     <value>Loading package information from file...</value>
   </data>


### PR DESCRIPTION
## 変更内容\n- SyncAsyncでインストール済み/ピン留めパッケージ取得時に進捗表示を追加\n- 進捗メッセージをリソースへ追加\n- 進捗表示のテストを追加\n\n## 背景・目的\n- WinGet取得が長い場合に無表示となるためUXを改善\n\n## 動作確認\n- \\scripts\\Run-CodeQuality.ps1