### PR TITLE
feat: Gistのパッケージを一覧表示するgistコマンドを追加

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -130,6 +130,7 @@ GistGetは独自のクラウド同期機能と、wingetの全コマンドをサ�
 | `auth status` | 現在の認証状態を表示 |
 | `sync` | Gistとパッケージを同期 |
 | `init` | 対話的にインストール済みパッケージを選択してGistを初期化 |
+| `gist` | Gistのパッケージを一覧表示 |
 | `install` | パッケージをインストールしてGistに保存 |
 | `uninstall` | パッケージをアンインストールしてGistを更新 |
 | `upgrade` | パッケージをアップグレードしてGistに保存 |

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ GistGet supports both its own cloud sync features and all winget commands.
 | `auth status` | Display current authentication status |
 | `sync` | Synchronize packages with Gist |
 | `init` | Interactively select installed packages to initialize Gist |
+| `gist` | List packages from Gist |
 | `install` | Install a package and save to Gist |
 | `uninstall` | Uninstall a package and update Gist |
 | `upgrade` | Upgrade a package and save to Gist |

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -12,6 +12,7 @@
     <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
     <PackageVersion Include="Microsoft.WindowsPackageManager.ComInterop" Version="1.12.420" />
     <!-- GitHub, YAML, CLI -->
+    <PackageVersion Include="FluentTextTable" Version="1.0.0" />
     <PackageVersion Include="Octokit" Version="14.0.0" />
     <PackageVersion Include="Sharprompt" Version="3.0.1" />
     <PackageVersion Include="Spectre.Console" Version="0.54.0" />

--- a/src/GistGet.slnx.DotSettings
+++ b/src/GistGet.slnx.DotSettings
@@ -54,4 +54,5 @@
 	<!-- Resource localization and naming suppressions -->
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=LocalizableElement/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=InconsistentNaming/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=NotOverriddenInSpecificCulture/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 </wpf:ResourceDictionary>

--- a/src/GistGet/GistGet.csproj
+++ b/src/GistGet/GistGet.csproj
@@ -19,6 +19,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="FluentTextTable" />
 		<PackageReference Include="Microsoft.Extensions.Hosting" />
 		<PackageReference Include="Microsoft.Windows.CsWinRT" />
 		<PackageReference Include="Microsoft.WindowsPackageManager.ComInterop" />

--- a/src/GistGet/GistPackageRow.cs
+++ b/src/GistGet/GistPackageRow.cs
@@ -1,0 +1,27 @@
+// Display model for Gist package list table.
+
+namespace GistGet;
+
+/// <summary>
+/// Represents a row in the Gist package list table.
+/// </summary>
+// ReSharper disable UnusedAutoPropertyAccessor.Global
+// Note: Properties are accessed via reflection by FluentTextTable
+public class GistPackageRow
+{
+    /// <summary>
+    /// Gets or sets the package identifier.
+    /// </summary>
+    public string Id { get; set; } = "";
+
+    /// <summary>
+    /// Gets or sets the package display name.
+    /// </summary>
+    public string Name { get; set; } = "";
+
+    /// <summary>
+    /// Gets or sets the pinned version (empty if not pinned).
+    /// </summary>
+    public string Pin { get; set; } = "";
+}
+// ReSharper restore UnusedAutoPropertyAccessor.Global

--- a/src/GistGet/IGistGetService.cs
+++ b/src/GistGet/IGistGetService.cs
@@ -61,4 +61,9 @@ public interface IGistGetService
     /// Initializes the Gist by interactively selecting installed packages.
     /// </summary>
     Task InitAsync();
+
+    /// <summary>
+    /// Lists packages from Gist.
+    /// </summary>
+    Task ListGistPackagesAsync();
 }

--- a/src/GistGet/Presentation/CommandBuilder.cs
+++ b/src/GistGet/Presentation/CommandBuilder.cs
@@ -30,7 +30,8 @@ public class CommandBuilder(IGistGetService gistGetService, IAnsiConsole console
             BuildInstallCommand(),
             BuildUninstallCommand(),
             BuildUpgradeCommand(),
-            BuildPinCommand()
+            BuildPinCommand(),
+            BuildGistCommand()
         };
 
         foreach (var cmd in BuildWingetPassthroughCommands())
@@ -453,6 +454,16 @@ public class CommandBuilder(IGistGetService gistGetService, IAnsiConsole console
         }, resetArgs);
         command.Add(reset);
 
+        return command;
+    }
+
+    private Command BuildGistCommand()
+    {
+        var command = new Command("gist", Messages.GistCommandDescription);
+        command.SetHandler(async () =>
+        {
+            await gistGetService.ListGistPackagesAsync();
+        });
         return command;
     }
 

--- a/src/GistGet/Resources/Messages.Designer.cs
+++ b/src/GistGet/Resources/Messages.Designer.cs
@@ -282,6 +282,12 @@ internal static class Messages
         ResourceManager.GetString("InitCommandDescription", null) ?? string.Empty;
 
     /// <summary>
+    /// Looks up a localized string similar to: Lists packages from Gist
+    /// </summary>
+    internal static string GistCommandDescription =>
+        ResourceManager.GetString("GistCommandDescription", null) ?? string.Empty;
+
+    /// <summary>
     /// Looks up a localized string similar to: Manage GitHub authentication
     /// </summary>
     internal static string AuthCommandDescription =>

--- a/src/GistGet/Resources/Messages.ja.resx
+++ b/src/GistGet/Resources/Messages.ja.resx
@@ -364,4 +364,7 @@
   <data name="WingetMcpCommandDescription" xml:space="preserve">
     <value>Model Context Protocol サーバー [パススルー]</value>
   </data>
+  <data name="GistCommandDescription" xml:space="preserve">
+    <value>Gistのパッケージを一覧表示します</value>
+  </data>
 </root>

--- a/src/GistGet/Resources/Messages.resx
+++ b/src/GistGet/Resources/Messages.resx
@@ -177,6 +177,9 @@
   <data name="InitCommandDescription" xml:space="preserve">
     <value>Initializes Gist by interactively selecting installed packages</value>
   </data>
+  <data name="GistCommandDescription" xml:space="preserve">
+    <value>Lists packages from Gist</value>
+  </data>
   <data name="AuthCommandDescription" xml:space="preserve">
     <value>Manage GitHub authentication</value>
   </data>


### PR DESCRIPTION
## 概要
Gist上の同期対象パッケージを一覧表示する新しい `gist` コマンドを追加しました。

## 変更内容
- **FluentTextTable (v1.0.0)** を依存関係に追加
- **GistPackageRow** モデルクラスを作成（Id、Name、Pin のプロパティ）
- **IGistGetService** に `ListGistPackagesAsync` メソッドを追加
- **GistGetService** に実装を追加（マークダウン形式のテーブル表示）
- **CommandBuilder** に `gist` コマンドを追加
- リソースファイル（Messages.resx、Messages.ja.resx）に説明を追加
- テストを追加（認証/未認証の両ケース）
- README.md、README.ja.md にコマンド一覧を更新
- ReSharper 設定を更新（警告の抑制）

## 出力例
```
| Id          | Name        | Pin   |
|-------------|-------------|-------|
| Package.One | Package One | 1.0.0 |
| Package.Two | Package Two |       |
```

## テスト計画
- [x] 未認証時に適切なメッセージが表示されること
- [x] 認証済みでパッケージが存在する場合、マークダウンテーブルが表示されること
- [x] カバレッジが 98.25% (閾値 98% 以上)
- [x] すべてのテスト (203件) が成功すること
- [x] ReSharper InspectCode で問題がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)