### PR TITLE
fix: SingleFile発行でWinGet依存を隣接配置

### DIFF
--- a/src/GistGet.Test/PublishArtifactsTests.cs
+++ b/src/GistGet.Test/PublishArtifactsTests.cs
@@ -1,0 +1,130 @@
+using System.Diagnostics;
+using Shouldly;
+
+namespace GistGet.Test;
+
+public class PublishArtifactsTests
+{
+	protected static readonly string ProjectPath = Path.GetFullPath(
+		Path.Combine(
+			AppContext.BaseDirectory,
+			"..",
+			"..",
+			"..",
+			"..",
+			"..",
+			"..",
+			"GistGet",
+			"GistGet.csproj"));
+
+	protected static readonly string PublishRoot = Path.Combine(Path.GetTempPath(), "GistGetPublishTests");
+
+	public class PortablePackage : PublishArtifactsTests
+	{
+		[Fact]
+		public void MissingLocalDll_ShouldStillRunExecutableAndKeepWinGetInteropBeside()
+		{
+			// -------------------------------------------------------------------
+			// Arrange
+			// -------------------------------------------------------------------
+			var publishDirectory = Path.Combine(PublishRoot, Guid.NewGuid().ToString("N"));
+			Directory.CreateDirectory(publishDirectory);
+
+			try
+			{
+				var publishResult = RunProcess(
+					"dotnet",
+					new[]
+					{
+						"publish",
+						ProjectPath,
+						"-c",
+						"Release",
+						"-r",
+						"win-x64",
+						"-o",
+						publishDirectory
+					});
+
+				publishResult.ExitCode.ShouldBe(0, publishResult.ToString());
+
+				var executablePath = Path.Combine(publishDirectory, "GistGet.exe");
+				File.Exists(executablePath).ShouldBeTrue();
+
+				var dllPath = Path.Combine(publishDirectory, "GistGet.dll");
+				if (File.Exists(dllPath))
+				{
+					File.Delete(dllPath);
+				}
+
+				var winGetInteropFiles = new[]
+				{
+					"Microsoft.Management.Deployment.CsWinRTProjection.dll",
+					"Microsoft.Management.Deployment.dll",
+					"Microsoft.Management.Deployment.winmd",
+					"WinRT.Runtime.dll"
+				};
+
+				foreach (var fileName in winGetInteropFiles)
+				{
+					var fullPath = Path.Combine(publishDirectory, fileName);
+					File.Exists(fullPath).ShouldBeTrue($"{fileName} should be present beside the executable");
+				}
+
+				// -------------------------------------------------------------------
+				// Act
+				// -------------------------------------------------------------------
+				var runResult = RunProcess(executablePath, new[] { "--version" }, publishDirectory);
+
+				// -------------------------------------------------------------------
+				// Assert
+				// -------------------------------------------------------------------
+				runResult.ExitCode.ShouldBe(0, runResult.ToString());
+				runResult.StandardOutput.ShouldNotBeNullOrWhiteSpace();
+			}
+			finally
+			{
+				if (Directory.Exists(publishDirectory))
+				{
+					Directory.Delete(publishDirectory, true);
+				}
+			}
+		}
+	}
+
+	protected static ProcessResult RunProcess(string fileName, IEnumerable<string> arguments, string? workingDirectory = null)
+	{
+		var startInfo = new ProcessStartInfo
+		{
+			FileName = fileName,
+			RedirectStandardOutput = true,
+			RedirectStandardError = true,
+			UseShellExecute = false,
+			WorkingDirectory = workingDirectory ?? Directory.GetCurrentDirectory()
+		};
+
+		foreach (var argument in arguments)
+		{
+			startInfo.ArgumentList.Add(argument);
+		}
+
+		using var process = new Process { StartInfo = startInfo };
+
+		process.Start();
+
+		var standardOutput = process.StandardOutput.ReadToEnd();
+		var standardError = process.StandardError.ReadToEnd();
+
+		process.WaitForExit();
+
+		return new ProcessResult(process.ExitCode, standardOutput.Trim(), standardError.Trim());
+	}
+
+	protected readonly record struct ProcessResult(int ExitCode, string StandardOutput, string StandardError)
+	{
+		public override string ToString()
+		{
+			return $"ExitCode: {ExitCode}, StdOut: {StandardOutput}, StdErr: {StandardError}";
+		}
+	}
+}

--- a/src/GistGet/GistGet.csproj
+++ b/src/GistGet/GistGet.csproj
@@ -14,8 +14,9 @@
 		<RepositoryType>git</RepositoryType>
 
 		<!-- 発行設定 -->
-		<PublishSingleFile>false</PublishSingleFile>
+		<PublishSingleFile>true</PublishSingleFile>
 		<SelfContained>true</SelfContained>
+		<UseAppHost>true</UseAppHost>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -44,5 +45,40 @@
 	<ItemGroup>
 	  <Folder Include="Properties\" />
 	</ItemGroup>
+
+	<Target Name="ExcludeWinGetFromSingleFile" AfterTargets="ComputeFilesToPublish">
+		<ItemGroup>
+			<ResolvedFileToPublish Update="@(ResolvedFileToPublish)"
+				Condition="
+					$([System.String]::Copy('%(ResolvedFileToPublish.Identity)').EndsWith('Microsoft.Management.Deployment.dll'))
+					Or $([System.String]::Copy('%(ResolvedFileToPublish.Identity)').EndsWith('Microsoft.Management.Deployment.CsWinRTProjection.dll'))
+					Or $([System.String]::Copy('%(ResolvedFileToPublish.Identity)').EndsWith('Microsoft.WindowsPackageManager.ComInterop.dll'))
+					Or $([System.String]::Copy('%(ResolvedFileToPublish.Identity)').EndsWith('Microsoft.Windows.CsWinRT.dll'))
+					Or $([System.String]::Copy('%(ResolvedFileToPublish.Identity)').EndsWith('WinRT.Runtime.dll'))
+					Or $([System.String]::Copy('%(ResolvedFileToPublish.Identity)').EndsWith('.winmd'))
+				">
+				<ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+				<CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+			</ResolvedFileToPublish>
+		</ItemGroup>
+	</Target>
+
+	<Target Name="CollectWinGetInteropFiles" AfterTargets="ResolveReferences">
+		<ItemGroup>
+			<WinGetInteropFile Include="@(ReferenceCopyLocalPaths)"
+				Condition="
+					$([System.String]::Copy('%(ReferenceCopyLocalPaths.Filename)').Equals('Microsoft.Management.Deployment'))
+					Or $([System.String]::Copy('%(ReferenceCopyLocalPaths.Filename)').Equals('Microsoft.Management.Deployment.CsWinRTProjection'))
+					Or $([System.String]::Copy('%(ReferenceCopyLocalPaths.Filename)').Equals('Microsoft.WindowsPackageManager.ComInterop'))
+					Or $([System.String]::Copy('%(ReferenceCopyLocalPaths.Filename)').Equals('Microsoft.Windows.CsWinRT'))
+					Or $([System.String]::Copy('%(ReferenceCopyLocalPaths.Filename)').Equals('WinRT.Runtime'))
+					Or $([System.String]::Copy('%(ReferenceCopyLocalPaths.Extension)').Equals('.winmd'))
+				" />
+		</ItemGroup>
+	</Target>
+
+	<Target Name="CopyWinGetInteropFiles" AfterTargets="Publish" DependsOnTargets="CollectWinGetInteropFiles">
+		<Copy SourceFiles="@(WinGetInteropFile)" DestinationFolder="$(PublishDir)" SkipUnchangedFiles="true" />
+	</Target>
 
 </Project>


### PR DESCRIPTION
## 概要
- PublishSingleFileを再有効化し、WinGet/WinRT依存ファイルをバンドルから除外して隣接配置
- 発行物を検証する統合テストを追加し、GistGet.dllなしでも起動確認

## テスト
- dotnet test src/GistGet.Test/GistGet.Test.csproj -c Debug -p:Platform=x64
